### PR TITLE
Translate basic elements from MaterialRippleLayout to using a ripple drawable

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/Activities/SettingsActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/Activities/SettingsActivity.java
@@ -93,7 +93,7 @@ public class SettingsActivity extends ThemedActivity {
         scr = (ScrollView)findViewById(R.id.settingAct_scrollView);
 
 
-        /*** EXCLUDED ALBUMS ***/
+        /*** BASIC THEME ***/
         findViewById(R.id.ll_basic_theme).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/res/drawable/ripple.xml
+++ b/app/src/main/res/drawable/ripple.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used in everything that is clickable so that they have a nice
+ripple effect under them. In order to make a view have a ripple effect
+when it is touched, simply set:
+
+android:background="@drawable/ripple
+
+The background color of this ripple drawable changes depending on the theme that the
+user has selected.
+-->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:color="#af0c0e"
+    android:color="@color/md_grey_500"
     tools:targetApi="lollipop">
-    <item android:id="@android:id/mask">
-        <shape android:shape="rectangle">
-            <solid android:color="#af0c0e" />
-        </shape>
-    </item>
+    <item android:id="@android:id/mask"
+        android:drawable="@color/md_amber_500" />
 </ripple>

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -365,7 +365,7 @@
                             android:textColor="@color/md_grey_400"
                             android:layout_marginTop="@dimen/small_spacing"
                             android:textSize="14sp"
-                        />
+                            />
                         <TextView
                             android:id="@+id/about_community_you_sub"
                             android:layout_width="wrap_content"
@@ -375,7 +375,7 @@
                             android:textColor="@color/md_grey_400"
                             android:textSize="14sp"
                             android:layout_marginBottom="16dp"
-                        />
+                            />
                         <!--<TextView
                             android:id="@+id/about_patryk_goworowski_googleplus_item"
                             android:layout_width="wrap_content"
@@ -419,253 +419,235 @@
                         />
 
                     <!--REPORT BUG-->
-                    <com.balysv.materialripple.MaterialRippleLayout
+
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_report_bug"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_support_report_bug_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="gmd-bug-report"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_report_bug"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="16dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="8dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_support_report_bug_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="gmd-bug-report"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_support_report_bug_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="16dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="8dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_support_report_bug_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_report_bug"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_support_report_bug_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_report_bug_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/about_support_report_bug"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_support_report_bug_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/about_support_report_bug_sub"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                    </LinearLayout>
 
                     <!-- TRANSLATE -->
-                    <com.balysv.materialripple.MaterialRippleLayout
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_support_translate"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_support_translate_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="gmd-flag"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_support_translate"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="8dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="8dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_support_translate_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="gmd-flag"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_support_translate_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="8dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="8dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_support_translate_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_translate"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_support_translate_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_translate_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/about_support_translate"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_support_translate_item_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/about_support_translate_sub"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                    </LinearLayout>
 
                     <!-- RATE -->
-                    <com.balysv.materialripple.MaterialRippleLayout
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_support_rate"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_support_rate_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="gmd-star"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_support_rate"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="8dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="8dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_support_rate_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="gmd-star"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_support_rate_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="8dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="8dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_support_rate_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_rate"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_support_rate_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_rate_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/about_support_rate"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_support_rate_item_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/about_support_rate_sub"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                    </LinearLayout>
+
                     <!-- GIT HUB -->
-                    <com.balysv.materialripple.MaterialRippleLayout
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_support_github"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_support_github_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="faw-github"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_support_github"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="8dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="8dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_support_github_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="faw-github"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_support_github_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="8dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="8dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_support_github_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_github"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_support_github_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_support_github_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/about_support_github"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_support_github_item_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/about_support_github_sub"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                    </LinearLayout>
 
                     <!-- DONATE -->
-                    <com.balysv.materialripple.MaterialRippleLayout
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_support_donate"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_support_donate_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="faw-gift"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_support_donate"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="8dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="16dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_support_donate_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="faw-gift"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_support_donate_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="8dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="16dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_support_donate_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/donate"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_support_donate_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/donate_sub_text"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/donate"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_support_donate_item_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/donate_sub_text"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                    </LinearLayout>
 
                 </LinearLayout>
             </android.support.v7.widget.CardView>
@@ -694,104 +676,97 @@
                         android:textSize="16sp"
                         android:textStyle="bold"
                         />
-                    <com.balysv.materialripple.MaterialRippleLayout
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_license"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_license_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="gmd-insert-drive-file"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_license"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="8dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="8dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_license_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="gmd-insert-drive-file"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_license_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="8dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="8dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_license_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_license"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_license_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_license_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/about_license"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_license_item_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/about_license_sub"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                    </LinearLayout>
 
-                    <com.balysv.materialripple.MaterialRippleLayout
+
+                    <LinearLayout
+                        xmlns:android="http://schemas.android.com/apk/res/android"
+                        android:id="@+id/ll_about_libs"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        app:mrl_rippleAlpha="0.05"
-                        app:mrl_rippleDelayClick="false">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
+                        >
+                        <com.mikepenz.iconics.view.IconicsImageView
+                            android:id="@+id/about_libs_icon"
+                            android:layout_width="@dimen/icon_width_height"
+                            android:layout_height="@dimen/icon_width_height"
+                            android:layout_gravity="center_vertical"
+                            app:iiv_icon="gmd-insert-drive-file"
+                            android:layout_marginLeft="@dimen/big_spacing"
+                            android:layout_marginRight="@dimen/big_spacing"
+                            />
                         <LinearLayout
-                            xmlns:android="http://schemas.android.com/apk/res/android"
-                            android:id="@+id/ll_about_libs"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
+                            android:orientation="vertical"
+                            android:paddingTop="8dp"
+                            android:paddingRight="16dp"
+                            android:paddingBottom="16dp"
                             >
-                            <com.mikepenz.iconics.view.IconicsImageView
-                                android:id="@+id/about_libs_icon"
-                                android:layout_width="@dimen/icon_width_height"
-                                android:layout_height="@dimen/icon_width_height"
-                                android:layout_gravity="center_vertical"
-                                app:iiv_icon="gmd-insert-drive-file"
-                                android:layout_marginLeft="@dimen/big_spacing"
-                                android:layout_marginRight="@dimen/big_spacing"
-                                />
-                            <LinearLayout
-                                android:layout_width="match_parent"
+                            <TextView
+                                android:id="@+id/about_libs_item"
+                                android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:paddingTop="8dp"
-                                android:paddingRight="16dp"
-                                android:paddingBottom="16dp"
-                                >
-                                <TextView
-                                    android:id="@+id/about_libs_item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_library_license"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
-                                    />
-                                <TextView
-                                    android:id="@+id/about_libs_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/about_library_license_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
+                                android:text="@string/about_library_license"
+                                android:textColor="@color/md_dark_background"
+                                android:textSize="16sp"
+                                />
+                            <TextView
+                                android:id="@+id/about_libs_item_sub"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="@string/about_library_license_sub"
+                                android:textColor="@color/md_grey_400"
+                                android:textSize="14sp"
+                                />
                         </LinearLayout>
-                    </com.balysv.materialripple.MaterialRippleLayout>
-               </LinearLayout>
+                    </LinearLayout>
+                </LinearLayout>
             </android.support.v7.widget.CardView>
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/activity_donate.xml
+++ b/app/src/main/res/layout/activity_donate.xml
@@ -259,9 +259,6 @@
                         />
                     </LinearLayout>
 
-                    <com.balysv.materialripple.MaterialRippleLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
                         <TextView
                             android:id="@+id/donate_bitcoin_item"
                             android:layout_width="match_parent"
@@ -271,8 +268,9 @@
                             android:text="13psCBkxAjvvssSDHHGGagG2R8b4SraVyu"
                             android:textColor="@color/md_dark_background"
                             android:textSize="@dimen/sub_medium_text"
-                        />
-                    </com.balysv.materialripple.MaterialRippleLayout>
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
+                            />
                 </LinearLayout>
             </android.support.v7.widget.CardView>
         </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -40,13 +40,12 @@
                     android:layout_marginBottom="10dp"
                     app:cardCornerRadius="1dp"
                     app:cardElevation="5dp"
-                >
+                    >
 
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
-
                         <TextView
                             android:id="@+id/general_setting_title"
                             android:layout_width="match_parent"
@@ -57,157 +56,145 @@
                             android:textColor="@color/md_dark_background"
                             android:textSize="16sp"
                             android:textStyle="bold"
-                        />
+                            />
 
                         <!-- SECURITY -->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_security"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false">
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
+                            >
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/security_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="faw-user-secret"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_security"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                            >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/security_icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="faw-user-secret"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                />
-                                <LinearLayout
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="16dp"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="16dp"
                                 >
-                                    <TextView
-                                        android:id="@+id/security_item_title"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/security"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
+                                <TextView
+                                    android:id="@+id/security_item_title"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/security"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
                                     />
-                                    <TextView
-                                        android:id="@+id/security_item_sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/security_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
+                                <TextView
+                                    android:id="@+id/security_item_sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/security_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
                                     />
-                                </LinearLayout>
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!-- NUMBER OF COLUMNS -->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_n_columns"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false">
-                            <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_n_columns"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
                             >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/n_columns_Icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-view-column"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/n_columns_Icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-view-column"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
                                 />
-                                <LinearLayout
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
+                                >
+                                <TextView
+                                    android:id="@+id/n_columns_Item_Title"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                >
-                                    <TextView
-                                        android:id="@+id/n_columns_Item_Title"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/multi_column"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
+                                    android:text="@string/multi_column"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
                                     />
-                                    <TextView
-                                        android:id="@+id/n_columns_Item_Title_Sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/multi_column_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
+                                <TextView
+                                    android:id="@+id/n_columns_Item_Title_Sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/multi_column_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
                                     />
-                                </LinearLayout>
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!-- EXCLUDED ALBUM-->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_excluded_album"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false">
-                            <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_excluded_album"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
                             >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/Excluded_Album_Icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-folder"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/Excluded_Album_Icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-folder"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
                                 />
-                                <LinearLayout
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
+                                >
+                                <TextView
+                                    android:id="@+id/Excluded_Album_Item_Title"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                >
-                                    <TextView
-                                        android:id="@+id/Excluded_Album_Item_Title"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/excluded_albums"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
+                                    android:text="@string/excluded_albums"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
                                     />
-                                    <TextView
-                                        android:id="@+id/Excluded_Album_Item_Title_Sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/excluded_albums_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
+                                <TextView
+                                    android:id="@+id/Excluded_Album_Item_Title_Sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/excluded_albums_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
                                     />
-                                </LinearLayout>
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!-- USE MEDIA STORE -->
                         <LinearLayout
@@ -216,7 +203,8 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:orientation="horizontal"
-                        >
+                            >
+
                             <com.mikepenz.iconics.view.IconicsImageView
                                 android:id="@+id/use_media_mediastore_Icon"
                                 android:layout_width="@dimen/icon_width_height"
@@ -225,7 +213,7 @@
                                 app:iiv_icon="gmd-photo-library"
                                 android:layout_marginLeft="@dimen/big_spacing"
                                 android:layout_marginRight="@dimen/big_spacing"
-                            />
+                                />
                             <RelativeLayout
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
@@ -234,7 +222,7 @@
                                 android:paddingTop="16dp"
                                 android:paddingRight="16dp"
                                 android:paddingBottom="8dp"
-                            >
+                                >
 
                                 <LinearLayout
                                     android:layout_width="match_parent"
@@ -242,7 +230,7 @@
                                     android:layout_centerVertical="true"
                                     android:orientation="vertical"
                                     android:layout_marginEnd="44dp"
-                                >
+                                    >
                                     <TextView
                                         android:id="@+id/use_media_mediastore_Item"
                                         android:layout_width="wrap_content"
@@ -250,7 +238,7 @@
                                         android:text="@string/use_mediastore_provider"
                                         android:textColor="@color/md_dark_background"
                                         android:textSize="16sp"
-                                    />
+                                        />
                                     <TextView
                                         android:id="@+id/use_media_mediastore_Item_sub"
                                         android:layout_width="wrap_content"
@@ -258,7 +246,7 @@
                                         android:text="@string/use_media_store_sub"
                                         android:textColor="@color/md_grey_400"
                                         android:textSize="14sp"
-                                    />
+                                        />
                                 </LinearLayout>
                                 <android.support.v7.widget.SwitchCompat
                                     android:id="@+id/sw_use_media_mediastore"
@@ -274,182 +262,161 @@
                         </LinearLayout>
 
                         <!-- MAPS PROVIDER-->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_map_provider"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false"
-                        >
-
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
+                            >
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/map_provider_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="faw-map-signs"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_map_provider"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                            >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/map_provider_icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="faw-map-signs"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                />
-                                <LinearLayout
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="16dp"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="16dp"
                                 >
-                                    <TextView
-                                        android:id="@+id/map_provider_item_title"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/map_provider"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
+                                <TextView
+                                    android:id="@+id/map_provider_item_title"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/map_provider"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
                                     />
-                                    <TextView
-                                        android:id="@+id/map_provider_item_sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/map_provider_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
+                                <TextView
+                                    android:id="@+id/map_provider_item_sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/map_provider_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
                                     />
-                                </LinearLayout>
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!-- AUTO UPDATE MEDIA -->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_auto_update_media"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false"
-                        >
-                            <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_auto_update_media"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
+                            >
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/auto_update_media_Icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-update"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
+                            <RelativeLayout
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
+                                android:gravity="center_vertical"
                                 android:orientation="horizontal"
-                            >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/auto_update_media_Icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-update"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                />
-                                <RelativeLayout
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content"
-                                    android:gravity="center_vertical"
-                                    android:orientation="horizontal"
-                                    android:paddingTop="16dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
+                                android:paddingTop="16dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
                                 >
 
-                                    <LinearLayout
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        android:layout_centerVertical="true"
-                                        android:orientation="vertical"
-                                        android:layout_marginEnd="44dp"
-                                    >
-                                        <TextView
-                                            android:id="@+id/auto_update_media_Item"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:text="@string/auto_update_media"
-                                            android:textColor="@color/md_dark_background"
-                                            android:textSize="16sp"
-                                        />
-                                        <TextView
-                                            android:id="@+id/auto_update_media_Item_sub"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:text="@string/auto_update_media_sub"
-                                            android:textColor="@color/md_grey_400"
-                                            android:textSize="14sp"
-                                        />
-                                    </LinearLayout>
-                                    <android.support.v7.widget.SwitchCompat
-                                        android:id="@+id/SetAutoUpdateMedia"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:layout_gravity="center_vertical"
-                                        android:button="@null"
-                                        android:hapticFeedbackEnabled="true"
-                                        android:layout_centerVertical="true"
-                                        android:layout_alignParentEnd="true" />
-                                </RelativeLayout>
-
-                            </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
-
-
-                        <!-- FAB OPTIONS -->
-                        <com.balysv.materialripple.MaterialRippleLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false"
-                            android:visibility="gone"
-                        >
-                            <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_fab_options"
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="horizontal"
-                            >
-
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/fab_options_icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-add-circle"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                />
                                 <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
+                                    android:layout_centerVertical="true"
                                     android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                >
+                                    android:layout_marginEnd="44dp"
+                                    >
                                     <TextView
-                                        android:id="@+id/fab_options_item_title"
+                                        android:id="@+id/auto_update_media_Item"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:text="@string/fab_options"
+                                        android:text="@string/auto_update_media"
                                         android:textColor="@color/md_dark_background"
                                         android:textSize="16sp"
-                                    />
+                                        />
                                     <TextView
-                                        android:id="@+id/fab_options_item_sub"
+                                        android:id="@+id/auto_update_media_Item_sub"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:text="@string/fab_options_sub"
+                                        android:text="@string/auto_update_media_sub"
                                         android:textColor="@color/md_grey_400"
                                         android:textSize="14sp"
-                                    />
+                                        />
                                 </LinearLayout>
-                            </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                                <android.support.v7.widget.SwitchCompat
+                                    android:id="@+id/SetAutoUpdateMedia"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:button="@null"
+                                    android:hapticFeedbackEnabled="true"
+                                    android:layout_centerVertical="true"
+                                    android:layout_alignParentEnd="true" />
+                            </RelativeLayout>
 
+                        </LinearLayout>
+
+                        <!-- FAB OPTIONS -->
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_fab_options"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            >
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/fab_options_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-add-circle"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
+                                >
+                                <TextView
+                                    android:id="@+id/fab_options_item_title"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/fab_options"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
+                                    />
+                                <TextView
+                                    android:id="@+id/fab_options_item_sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/fab_options_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
+                                    />
+                            </LinearLayout>
+                        </LinearLayout>
 
                     </LinearLayout>
                 </android.support.v7.widget.CardView>
@@ -467,7 +434,7 @@
                     android:scaleType="centerInside"
                     android:layout_marginBottom="0dp"
                     app:elevation="5dp"
-                />
+                    />
 
             </FrameLayout>
 
@@ -501,211 +468,192 @@
                             android:textStyle="bold"
                             />
                         <!--BASIC THEME-->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_basic_theme"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
                             >
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/basic_theme_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-invert-colors"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_basic_theme"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
+                                android:orientation="vertical"
+                                android:paddingTop="16dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
                                 >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/basic_theme_icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-invert-colors"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                    />
-                                <LinearLayout
-                                    android:layout_width="match_parent"
+                                <TextView
+                                    android:id="@+id/basic_theme_item"
+                                    android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="16dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                    >
-                                    <TextView
-                                        android:id="@+id/basic_theme_item"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/basic_theme"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
-                                        />
-                                    <TextView
-                                        android:id="@+id/basic_theme_item_sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/basic_theme_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
-                                        />
-                                </LinearLayout>
+                                    android:text="@string/basic_theme"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
+                                    />
+                                <TextView
+                                    android:id="@+id/basic_theme_item_sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/basic_theme_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
+                                    />
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
 
                         <!--PRIMARY COLOR-->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_primaryColor"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
                             >
+
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/PrimaryColor_Icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-color-lens"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_primaryColor"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
                                 >
-
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/PrimaryColor_Icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-color-lens"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                    />
-                                <LinearLayout
-                                    android:layout_width="match_parent"
+                                <TextView
+                                    android:id="@+id/PrimaryColor_Item"
+                                    android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                    >
-                                    <TextView
-                                        android:id="@+id/PrimaryColor_Item"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/primary_color"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
-                                        />
-                                    <TextView
-                                        android:id="@+id/PrimaryColor_Item_Sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/primary_color_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
-                                        />
-                                </LinearLayout>
+                                    android:text="@string/primary_color"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
+                                    />
+                                <TextView
+                                    android:id="@+id/PrimaryColor_Item_Sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/primary_color_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
+                                    />
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!--ACCENT COLOR-->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_accentColor"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false">
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
+                            >
+
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/accentColor_Icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="cmd-format-color-fill"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_accentColor"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
                                 >
-
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/accentColor_Icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="cmd-format-color-fill"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                    />
-                                <LinearLayout
-                                    android:layout_width="match_parent"
+                                <TextView
+                                    android:id="@+id/accentColor_Item"
+                                    android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                    >
-                                    <TextView
-                                        android:id="@+id/accentColor_Item"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/accent_color"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
-                                        />
-                                    <TextView
-                                        android:id="@+id/accentColor_Item_Sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/accent_color_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
-                                        />
-                                </LinearLayout>
+                                    android:text="@string/accent_color"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
+                                    />
+                                <TextView
+                                    android:id="@+id/accentColor_Item_Sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/accent_color_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
+                                    />
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!-- APPLY THEME ON 3TH ACT -->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout
+                            xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_custom_thirdAct"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            app:mrl_rippleDelayClick="false"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
                             >
+
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/custom_3thAct_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="faw-paint-brush"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <LinearLayout
-                                xmlns:android="http://schemas.android.com/apk/res/android"
-                                android:id="@+id/ll_custom_thirdAct"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal"
+                                android:orientation="vertical"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="8dp"
                                 >
-
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/custom_3thAct_icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="faw-paint-brush"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
-                                    />
-                                <LinearLayout
-                                    android:layout_width="match_parent"
+                                <TextView
+                                    android:id="@+id/custom_3thAct_title"
+                                    android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:orientation="vertical"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="8dp"
-                                    >
-                                    <TextView
-                                        android:id="@+id/custom_3thAct_title"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/custom_3thAct"
-                                        android:textColor="@color/md_dark_background"
-                                        android:textSize="16sp"
-                                        />
-                                    <TextView
-                                        android:id="@+id/custom_3thAct_Sub"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:text="@string/custom_3thAct_sub"
-                                        android:textColor="@color/md_grey_400"
-                                        android:textSize="14sp"
-                                        />
-                                </LinearLayout>
+                                    android:text="@string/custom_3thAct"
+                                    android:textColor="@color/md_dark_background"
+                                    android:textSize="16sp"
+                                    />
+                                <TextView
+                                    android:id="@+id/custom_3thAct_Sub"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:text="@string/custom_3thAct_sub"
+                                    android:textColor="@color/md_grey_400"
+                                    android:textSize="14sp"
+                                    />
                             </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                        </LinearLayout>
 
                         <!--ADVANCED SETTING
                         android:visibility="gone"
@@ -848,7 +796,7 @@
 
                 </android.support.v7.widget.CardView>
 
-                 <!--TODO: I WILL WORK ON IT LATER-->
+                <!--TODO: I WILL WORK ON IT LATER-->
 
                 <android.support.design.widget.FloatingActionButton
                     android:visibility="gone"
@@ -878,7 +826,7 @@
                     android:layout_marginBottom="10dp"
                     app:cardCornerRadius="1dp"
                     app:cardElevation="5dp"
-                >
+                    >
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -896,22 +844,22 @@
                             android:textSize="16sp"
                             android:textStyle="bold" />
 
-                    <!--MAX BRIGHTNESS-->
-                    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_max_luminosity"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        >
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/ll_switch_max_luminosity_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-settings-brightness"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing"
-                            />
+                        <!--MAX BRIGHTNESS-->
+                        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_switch_max_luminosity"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            >
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/ll_switch_max_luminosity_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-settings-brightness"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
+                                />
                             <RelativeLayout
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
@@ -920,51 +868,51 @@
                                 android:paddingTop="16dp"
                                 android:paddingRight="16dp"
                                 android:paddingBottom="8dp"
-                            >
+                                >
                                 <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:layout_centerVertical="true"
                                     android:orientation="vertical"
                                     android:layout_marginEnd="45dp"
-                                >
-                                <TextView
-                                    android:id="@+id/max_luminosity_Item"
+                                    >
+                                    <TextView
+                                        android:id="@+id/max_luminosity_Item"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/max_brightness"
+                                        android:textColor="@color/md_dark_background"
+                                        android:textSize="16sp"
+                                        />
+                                    <TextView
+                                        android:id="@+id/max_luminosity_Item_Sub"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/max_brightness_sub"
+                                        android:textColor="@color/md_grey_400"
+                                        android:textSize="14sp"
+                                        />
+                                </LinearLayout>
+                                <android.support.v7.widget.SwitchCompat
+                                    android:id="@+id/set_max_luminosity"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:text="@string/max_brightness"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp"
+                                    android:layout_gravity="center_vertical"
+                                    android:button="@null"
+                                    android:hapticFeedbackEnabled="true"
+                                    android:layout_centerVertical="true"
+                                    android:layout_alignParentEnd="true"
                                     />
-                                <TextView
-                                    android:id="@+id/max_luminosity_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/max_brightness_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp"
-                                    />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/set_max_luminosity"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true"
-                                />
                             </RelativeLayout>
                         </LinearLayout>
 
                         <!-- PICTURE ORIENTATION-->
                         <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                      android:id="@+id/ll_switch_picture_orientation"
-                                      android:layout_width="match_parent"
-                                      android:layout_height="wrap_content"
-                                      android:orientation="horizontal"
-                        >
+                            android:id="@+id/ll_switch_picture_orientation"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            >
                             <com.mikepenz.iconics.view.IconicsImageView
                                 android:id="@+id/ll_switch_picture_orientation_icon"
                                 android:layout_width="@dimen/icon_width_height"
@@ -973,7 +921,7 @@
                                 app:iiv_icon="gmd-screen-rotation"
                                 android:layout_marginLeft="@dimen/big_spacing"
                                 android:layout_marginRight="@dimen/big_spacing"
-                            />
+                                />
                             <RelativeLayout
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
@@ -982,13 +930,13 @@
                                 android:paddingTop="8dp"
                                 android:paddingRight="16dp"
                                 android:paddingBottom="8dp"
-                            >
+                                >
                                 <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:orientation="vertical"
                                     android:layout_marginEnd="45dp"
-                                >
+                                    >
                                     <TextView
                                         android:id="@+id/picture_orientation_Item"
                                         android:layout_width="wrap_content"
@@ -996,7 +944,7 @@
                                         android:text="@string/picture_orientation"
                                         android:textColor="@color/md_dark_background"
                                         android:textSize="16sp"
-                                    />
+                                        />
                                     <TextView
                                         android:id="@+id/picture_orientation_Item_Sub"
                                         android:layout_width="wrap_content"
@@ -1004,7 +952,7 @@
                                         android:text="@string/picture_orientation_sub"
                                         android:textColor="@color/md_grey_400"
                                         android:textSize="14sp"
-                                    />
+                                        />
                                 </LinearLayout>
                                 <android.support.v7.widget.SwitchCompat
                                     android:id="@+id/set_picture_orientation"
@@ -1015,76 +963,71 @@
                                     android:hapticFeedbackEnabled="true"
                                     android:layout_centerVertical="true"
                                     android:layout_alignParentEnd="true"
-                                />
+                                    />
                             </RelativeLayout>
                         </LinearLayout>
 
                         <!-- FULL resolution TODO: remove -->
-                        <com.balysv.materialripple.MaterialRippleLayout
+                        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                            android:id="@+id/ll_switch_full_resolution"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            app:mrl_rippleAlpha="0.05"
-                            android:visibility="gone"
-                            app:mrl_rippleDelayClick="false">
-                            <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                                          android:id="@+id/ll_switch_full_resolution"
-                                          android:layout_width="match_parent"
-                                          android:layout_height="wrap_content"
-                                          android:orientation="horizontal"
+                            android:orientation="horizontal"
+                            android:background="@drawable/ripple"
+                            android:clickable="true"
                             >
-                                <com.mikepenz.iconics.view.IconicsImageView
-                                    android:id="@+id/ll_switch_full_resolution_icon"
-                                    android:layout_width="@dimen/icon_width_height"
-                                    android:layout_height="@dimen/icon_width_height"
-                                    android:layout_gravity="center_vertical"
-                                    app:iiv_icon="gmd-image"
-                                    android:layout_marginLeft="@dimen/big_spacing"
-                                    android:layout_marginRight="@dimen/big_spacing"
+                            <com.mikepenz.iconics.view.IconicsImageView
+                                android:id="@+id/ll_switch_full_resolution_icon"
+                                android:layout_width="@dimen/icon_width_height"
+                                android:layout_height="@dimen/icon_width_height"
+                                android:layout_gravity="center_vertical"
+                                app:iiv_icon="gmd-image"
+                                android:layout_marginLeft="@dimen/big_spacing"
+                                android:layout_marginRight="@dimen/big_spacing"
                                 />
-                                <RelativeLayout
+                            <RelativeLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="center_vertical"
+                                android:orientation="horizontal"
+                                android:paddingTop="8dp"
+                                android:paddingRight="16dp"
+                                android:paddingBottom="16dp"
+                                >
+                                <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
-                                    android:gravity="center_vertical"
-                                    android:orientation="horizontal"
-                                    android:paddingTop="8dp"
-                                    android:paddingRight="16dp"
-                                    android:paddingBottom="16dp"
-                                >
-                                    <LinearLayout
-                                        android:layout_width="match_parent"
-                                        android:layout_height="wrap_content"
-                                        android:orientation="vertical"
-                                        android:layout_marginEnd="45dp"
+                                    android:orientation="vertical"
+                                    android:layout_marginEnd="45dp"
                                     >
-                                        <TextView
-                                            android:id="@+id/full_resolution_Item"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:text="@string/delay_load_full_size_image"
-                                            android:textColor="@color/md_dark_background"
-                                            android:textSize="16sp"
-                                        />
-                                        <TextView
-                                            android:id="@+id/full_resolution_Item_Sub"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:text="@string/load_full_image_when_zoom_in"
-                                            android:textColor="@color/md_grey_400"
-                                            android:textSize="14sp" />
-                                    </LinearLayout>
-                                    <android.support.v7.widget.SwitchCompat
-                                        android:id="@+id/set_full_resolution"
+                                    <TextView
+                                        android:id="@+id/full_resolution_Item"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:layout_gravity="center_vertical"
-                                        android:button="@null"
-                                        android:hapticFeedbackEnabled="true"
-                                        android:layout_centerVertical="true"
-                                        android:layout_alignParentEnd="true"
+                                        android:text="@string/delay_load_full_size_image"
+                                        android:textColor="@color/md_dark_background"
+                                        android:textSize="16sp"
+                                        />
+                                    <TextView
+                                        android:id="@+id/full_resolution_Item_Sub"
+                                        android:layout_width="wrap_content"
+                                        android:layout_height="wrap_content"
+                                        android:text="@string/load_full_image_when_zoom_in"
+                                        android:textColor="@color/md_grey_400"
+                                        android:textSize="14sp" />
+                                </LinearLayout>
+                                <android.support.v7.widget.SwitchCompat
+                                    android:id="@+id/set_full_resolution"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:button="@null"
+                                    android:hapticFeedbackEnabled="true"
+                                    android:layout_centerVertical="true"
+                                    android:layout_alignParentEnd="true"
                                     />
-                                </RelativeLayout>
-                            </LinearLayout>
-                        </com.balysv.materialripple.MaterialRippleLayout>
+                            </RelativeLayout>
+                        </LinearLayout>
 
                         <!--SWIPE ORIENTATION-->
                         <LinearLayout
@@ -1092,9 +1035,10 @@
                             android:id="@+id/ll_media_viewer_swipe_direction"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
+                            android:gravity="center_vertical"
                             android:orientation="horizontal"
                             android:visibility="gone"
-                        >
+                            >
                             <com.mikepenz.iconics.view.IconicsImageView
                                 android:id="@+id/media_viewer_swipe_direction_Icon"
                                 android:layout_width="@dimen/icon_width_height"
@@ -1103,7 +1047,7 @@
                                 app:iiv_icon="gmd-compare-arrows"
                                 android:layout_marginLeft="@dimen/big_spacing"
                                 android:layout_marginRight="@dimen/big_spacing"
-                            />
+                                />
                             <RelativeLayout
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
@@ -1112,14 +1056,14 @@
                                 android:paddingTop="16dp"
                                 android:paddingRight="16dp"
                                 android:paddingBottom="16dp"
-                            >
+                                >
                                 <LinearLayout
                                     android:layout_width="match_parent"
                                     android:layout_height="wrap_content"
                                     android:layout_centerVertical="true"
                                     android:orientation="vertical"
                                     android:layout_marginEnd="44dp"
-                                >
+                                    >
                                     <TextView
                                         android:id="@+id/media_viewer_swipe_direction_Item"
                                         android:layout_width="wrap_content"
@@ -1127,7 +1071,7 @@
                                         android:text="@string/media_viewer_swipe_direction"
                                         android:textColor="@color/md_dark_background"
                                         android:textSize="16sp"
-                                    />
+                                        />
                                     <TextView
                                         android:id="@+id/media_viewer_swipe_direction_sub"
                                         android:layout_width="wrap_content"
@@ -1135,7 +1079,7 @@
                                         android:text="@string/media_viewer_swipe_direction_sub"
                                         android:textColor="@color/md_grey_400"
                                         android:textSize="14sp"
-                                    />
+                                        />
                                 </LinearLayout>
                                 <android.support.v7.widget.SwitchCompat
                                     android:id="@+id/Set_media_viewer_swipe_direction"
@@ -1148,6 +1092,7 @@
                                     android:layout_alignParentEnd="true" />
                             </RelativeLayout>
                         </LinearLayout>
+
                     </LinearLayout>
                 </android.support.v7.widget.CardView>
             </FrameLayout>

--- a/app/src/main/res/layout/dialog_basic_theme.xml
+++ b/app/src/main/res/layout/dialog_basic_theme.xml
@@ -35,165 +35,147 @@
                 android:paddingRight="@dimen/medium_spacing"
                 >
                 <!--WHITE THEME-->
-                <com.balysv.materialripple.MaterialRippleLayout
+                <LinearLayout
+                    xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:id="@+id/ll_white_basic_theme"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
+                    android:orientation="horizontal"
+                    android:padding="10dp"
+                    android:weightSum="10"
+                    android:background="@color/md_light_background"
+                    >
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/white_basic_theme_icon"
+                        android:layout_width="0dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="2"
+                        app:iiv_icon="gmd-invert-colors"
+                        app:iiv_color="@color/md_light_primary_icon"
+                        />
                     <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_white_basic_theme"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:padding="10dp"
-                        android:weightSum="10"
-                        android:background="@color/md_light_background"
+                        android:layout_weight="6"
+                        android:orientation="vertical"
                         >
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/white_basic_theme_icon"
-                            android:layout_width="0dp"
-                            android:layout_height="20dp"
-                            android:layout_gravity="center_vertical"
-                            android:layout_weight="2"
-                            app:iiv_icon="gmd-invert-colors"
-                            app:iiv_color="@color/md_light_primary_icon"
-                            />
-                        <LinearLayout
-                            android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/white_basic_theme_item"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_weight="6"
-                            android:orientation="vertical"
-                            >
-                            <TextView
-                                android:id="@+id/white_basic_theme_item"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/white_basic_theme"
-                                android:textColor="@color/md_light_primary_text"
-                                android:layout_gravity="center_vertical"
-                                android:textSize="16sp"
-                                />
-                        </LinearLayout>
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/white_basic_theme_select"
-                            android:layout_width="0dp"
-                            android:layout_height="20dp"
+                            android:text="@string/white_basic_theme"
+                            android:textColor="@color/md_light_primary_text"
                             android:layout_gravity="center_vertical"
-                            android:layout_weight="2"
-                            app:iiv_icon="gmd-done"
-                            app:iiv_color="@color/md_light_primary_icon"
+                            android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/white_basic_theme_select"
+                        android:layout_width="0dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="2"
+                        app:iiv_icon="gmd-done"
+                        app:iiv_color="@color/md_light_primary_icon"
+                        />
+                </LinearLayout>
 
                 <!--DARK THEME-->
-                <com.balysv.materialripple.MaterialRippleLayout
+                <LinearLayout
+                    xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:id="@+id/ll_dark_basic_theme"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
+                    android:orientation="horizontal"
+                    android:padding="10dp"
+                    android:weightSum="10"
+                    android:clickable="true"
+                    android:background="@color/md_dark_background"
+                    >
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/dark_basic_theme_icon"
+                        android:layout_width="0dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="2"
+                        app:iiv_icon="gmd-invert-colors"
+                        app:iiv_color="@color/md_dark_primary_icon"
+                        />
                     <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_dark_basic_theme"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:padding="10dp"
-                        android:weightSum="10"
-                        android:clickable="true"
-                        android:background="@color/md_dark_background"
+                        android:layout_weight="6"
+                        android:orientation="vertical"
                         >
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/dark_basic_theme_icon"
-                            android:layout_width="0dp"
-                            android:layout_height="20dp"
-                            android:layout_gravity="center_vertical"
-                            android:layout_weight="2"
-                            app:iiv_icon="gmd-invert-colors"
-                            app:iiv_color="@color/md_dark_primary_icon"
-                            />
-                        <LinearLayout
-                            android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/dark_basic_theme_item"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_weight="6"
-                            android:orientation="vertical"
-                            >
-                            <TextView
-                                android:id="@+id/dark_basic_theme_item"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/dark_basic_theme"
-                                android:textColor="@color/md_dark_primary_text"
-                                android:layout_gravity="center_vertical"
-                                android:textSize="16sp"
-                                />
-                        </LinearLayout>
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/dark_basic_theme_select"
-                            android:layout_width="0dp"
-                            android:layout_height="20dp"
+                            android:text="@string/dark_basic_theme"
+                            android:textColor="@color/md_dark_primary_text"
                             android:layout_gravity="center_vertical"
-                            android:layout_weight="2"
-                            app:iiv_icon="gmd-done"
-                            app:iiv_color="@color/md_dark_primary_icon"
+                            android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/dark_basic_theme_select"
+                        android:layout_width="0dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="2"
+                        app:iiv_icon="gmd-done"
+                        app:iiv_color="@color/md_dark_primary_icon"
+                        />
+                </LinearLayout>
 
                 <!--DARK AMOLED THEME-->
-                <com.balysv.materialripple.MaterialRippleLayout
+                <LinearLayout
+                    xmlns:android="http://schemas.android.com/apk/res/android"
+                    android:id="@+id/ll_dark_amoled_basic_theme"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
+                    android:orientation="horizontal"
+                    android:padding="10dp"
+                    android:weightSum="10"
+                    android:clickable="true"
+                    android:background="@color/md_black_1000"
+                    >
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/dark_amoled_basic_theme_icon"
+                        android:layout_width="0dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="2"
+                        app:iiv_icon="gmd-invert-colors"
+                        app:iiv_color="@color/md_dark_primary_icon"
+                        />
                     <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_dark_amoled_basic_theme"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:padding="10dp"
-                        android:weightSum="10"
-                        android:clickable="true"
-                        android:background="@color/md_black_1000"
+                        android:layout_weight="6"
+                        android:orientation="vertical"
                         >
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/dark_amoled_basic_theme_icon"
-                            android:layout_width="0dp"
-                            android:layout_height="20dp"
-                            android:layout_gravity="center_vertical"
-                            android:layout_weight="2"
-                            app:iiv_icon="gmd-invert-colors"
-                            app:iiv_color="@color/md_dark_primary_icon"
-                            />
-                        <LinearLayout
-                            android:layout_width="0dp"
+                        <TextView
+                            android:id="@+id/dark_amoled_basic_theme_item"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_weight="6"
-                            android:orientation="vertical"
-                            >
-                            <TextView
-                                android:id="@+id/dark_amoled_basic_theme_item"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/dark_amoled_basic_theme"
-                                android:textColor="@color/md_dark_primary_text"
-                                android:layout_gravity="center_vertical"
-                                android:textSize="16sp"
-                                />
-                        </LinearLayout>
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/dark_amoled_basic_theme_select"
-                            android:layout_width="0dp"
-                            android:layout_height="20dp"
+                            android:text="@string/dark_amoled_basic_theme"
+                            android:textColor="@color/md_dark_primary_text"
                             android:layout_gravity="center_vertical"
-                            android:layout_weight="2"
-                            app:iiv_icon="gmd-done"
-                            app:iiv_color="@color/md_dark_primary_icon"
+                            android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
+                    <com.mikepenz.iconics.view.IconicsImageView
+                        android:id="@+id/dark_amoled_basic_theme_select"
+                        android:layout_width="0dp"
+                        android:layout_height="20dp"
+                        android:layout_gravity="center_vertical"
+                        android:layout_weight="2"
+                        app:iiv_icon="gmd-done"
+                        app:iiv_color="@color/md_dark_primary_icon"
+                        />
+                </LinearLayout>
 
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/drawer_main_activity.xml
+++ b/app/src/main/res/layout/drawer_main_activity.xml
@@ -59,18 +59,15 @@
                 >
 
                 <!-- DEFAULT ALBUMS -->
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false"
-                    >
+
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_Default"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -93,21 +90,16 @@
                             android:paddingBottom="16dp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
 
                 <!-- HIDDEN ALBUMS -->
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false"
-                    >
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_hidden"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -130,21 +122,17 @@
                             android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
 
                 <!-- TAGS ALBUMS -->
                 <!--
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_Tags"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -167,21 +155,17 @@
                             android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
                 -->
                 <!-- TIMELINE -->
                 <!--
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_Moments"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -203,21 +187,16 @@
                             android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
                 -->
 
                 <!-- WALLPAPERS -->
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
-
                     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_Wallpapers"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
+                        android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true">
 
                         <com.mikepenz.iconics.view.IconicsImageView
                             android:id="@+id/Drawer_wallpapers_Icon"
@@ -238,7 +217,6 @@
                             android:textColor="@color/md_dark_background"
                             android:textSize="16sp" />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
 
                 <!--TODO: FIX THE LITTLE GRADIENT SHADOW-->
 
@@ -253,17 +231,14 @@
 
 
                 <!--DONATE-->
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_Donate"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -286,20 +261,16 @@
                             android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
 
                 <!-- SETTING -->
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_Setting"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -322,20 +293,16 @@
                             android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
 
                 <!-- ABOUT -->
-                <com.balysv.materialripple.MaterialRippleLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:mrl_rippleAlpha="0.05"
-                    app:mrl_rippleDelayClick="false">
                     <LinearLayout
                         xmlns:android="http://schemas.android.com/apk/res/android"
                         android:id="@+id/ll_drawer_About"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="horizontal"
+                        android:background="@drawable/ripple"
+                        android:clickable="true"
                         >
 
                         <com.mikepenz.iconics.view.IconicsImageView
@@ -358,7 +325,6 @@
                             android:textSize="16sp"
                             />
                     </LinearLayout>
-                </com.balysv.materialripple.MaterialRippleLayout>
 
             </LinearLayout>
         </LinearLayout>


### PR DESCRIPTION
This PR addresses an issue wherein user's couldn't see a ripple when using the AMOLED theme

https://github.com/HoraApps/LeafPic/issues/141

The problem in the issue was resolved by making the ripple a color that is visible within all themes.

This pull request has a few followup items:
1. Try to move all Ripples away from [MaterialRippleLayout](https://github.com/balysv/material-ripple) -- Ripples are supported officially now and the app should transition to them.
2. If the grey color chosen for all ripples is undesirable, the ripple color should change with the theme color. It is easy enough to change the color of the Ripple drawable; however, I'm unclear on how to update all views with the ripple drawable as their background.

Anywho, this PR fixes the above issue and begins a transition away from [MaterialRippleLayout](https://github.com/balysv/material-ripple). I hope to see it merged!
