### PR TITLE
Added support for excluding individual media files

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/Activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/Activities/MainActivity.java
@@ -878,6 +878,7 @@ public class MainActivity extends SharedMediaActivity {
 	togglePrimaryToolbarOptions(menu);
 	updateSelectedStuff();
 
+	  menu.findItem(R.id.excludeAlbumButton).setVisible(editMode);
 	menu.findItem(R.id.select_all).setVisible(editMode);
 	menu.findItem(R.id.installShortcut).setVisible(albumsMode && editMode);
 	menu.findItem(R.id.type_sort_action).setVisible(!albumsMode);
@@ -1059,6 +1060,13 @@ public class MainActivity extends SharedMediaActivity {
 
 		return true;
 	  case R.id.excludeAlbumButton:
+		  if (!this.albumsMode && this.editMode) {
+			  getAlbum().excludeSelectedPhotos(this);
+
+			  mediaAdapter.notifyDataSetChanged();
+			  albumsAdapter.notifyDataSetChanged();
+			  return true;
+		  }
 
 		final AlertDialog.Builder excludeDialogBuilder = new AlertDialog.Builder(MainActivity.this, getDialogStyle());
 

--- a/app/src/main/java/org/horaapps/leafpic/Activities/PhotoPagerActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/Activities/PhotoPagerActivity.java
@@ -35,6 +35,7 @@ import org.horaapps.leafpic.Adapters.MediaPagerAdapter;
 import org.horaapps.leafpic.Animations.DepthPageTransformer;
 import org.horaapps.leafpic.Data.Album;
 import org.horaapps.leafpic.Data.AlbumSettings;
+import org.horaapps.leafpic.Data.CustomAlbumsHandler;
 import org.horaapps.leafpic.Fragments.ImageFragment;
 import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.SelectAlbumBottomSheet;
@@ -347,6 +348,12 @@ public class PhotoPagerActivity extends SharedMediaActivity {
                 }
                 break;
 
+            case R.id.action_exclude:
+                this.getAlbum().excludeCurrentMedia(this);
+                adapter.notifyDataSetChanged();
+                toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
+                break;
+
             case R.id.action_copy:
                 bottomSheetDialogFragment = new SelectAlbumBottomSheet();
                 bottomSheetDialogFragment.setTitle(getString(R.string.copy_to));
@@ -446,8 +453,6 @@ public class PhotoPagerActivity extends SharedMediaActivity {
                                 public void onClick(DialogInterface dialog, int which) {
                                     if (securityObj.checkPassword(editTextPassword.getText().toString())) {
                                         deleteCurrentMedia();
-                                        adapter.notifyDataSetChanged();
-                                        toolbar.setTitle((mViewPager.getCurrentItem() + 1) + " " + getString(R.string.of) + " " + getAlbum().getMedia().size());
                                     } else
                                         Toast.makeText(passwordDialogBuilder.getContext(), R.string.wrong_password, Toast.LENGTH_SHORT).show();
 

--- a/app/src/main/java/org/horaapps/leafpic/Data/Album.java
+++ b/app/src/main/java/org/horaapps/leafpic/Data/Album.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by dnld on 26/04/16.
@@ -49,6 +51,7 @@ public class Album implements Serializable {
 	this.path = path;
 	this.name = name;
   }
+
 
   public Album(String path, String name, int count, String storageRootPath) {
 	this(path, name, count);
@@ -107,7 +110,15 @@ public class Album implements Serializable {
 	return mediaArrayList;
   }
 
+	public void excludeSelectedPhotos(Context context) {
+		CustomAlbumsHandler albumHandler = new CustomAlbumsHandler(context);
+		albumHandler.excludePhotos(this.selectedMedias, this.getId(), this.getPath());
+		this.media.removeAll(this.selectedMedias);
+	}
+
   public void updatePhotos(Context context) {
+	  CustomAlbumsHandler albumHandler = new CustomAlbumsHandler(context);
+	  Set<String> excludedPhotoPaths = albumHandler.getExcludedPhotos(this.getPath(), this.getId());
 	PreferenceUtil SP = PreferenceUtil.getInstance(context);
 	ArrayList<Media> mediaArrayList = new ArrayList<Media>();
 	if (isFromMediaStore()) {
@@ -119,6 +130,12 @@ public class Album implements Serializable {
 			  getPath(),filter,
 			  SP.getBoolean("set_include_video", true)));
 	}
+
+	  for (int i = mediaArrayList.size() - 1; i >= 0; i--) {
+		  if (excludedPhotoPaths.contains(mediaArrayList.get(i).getPath()))
+			  mediaArrayList.remove(i);
+	  }
+
 	media = mediaArrayList;
 	sortPhotos();
 	setCount(media.size());
@@ -418,6 +435,13 @@ public class Album implements Serializable {
 	}
 	return success;
   }
+
+	public void excludeCurrentMedia(Context context) {
+		CustomAlbumsHandler handler = new CustomAlbumsHandler(context);
+		handler.excludePhoto(this.getCurrentMedia(), this.getId(), this.getPath());
+		media.remove(getCurrentMediaIndex());
+		setCount(media.size());
+	}
 
   private boolean deleteMedia(Context context, Media media) {
 	boolean success;

--- a/app/src/main/java/org/horaapps/leafpic/Data/SimpleMediaIdentifier.java
+++ b/app/src/main/java/org/horaapps/leafpic/Data/SimpleMediaIdentifier.java
@@ -1,0 +1,29 @@
+package org.horaapps.leafpic.Data;
+
+/**
+ * Created by brand on 8/12/2016.
+ */
+public class SimpleMediaIdentifier {
+    String albumPath;
+    long albumId;
+
+    public String getMediaPath() {
+        return mediaPath;
+    }
+
+    public String getAlbumPath() {
+        return albumPath;
+    }
+
+    public long getAlbumId() {
+        return albumId;
+    }
+
+    String mediaPath;
+
+    public SimpleMediaIdentifier(String albumPath, long albumId, String mediaPath) {
+        this.albumPath = albumPath;
+        this.albumId = albumId;
+        this.mediaPath = mediaPath;
+    }
+}

--- a/app/src/main/res/menu/menu_view_pager.xml
+++ b/app/src/main/res/menu/menu_view_pager.xml
@@ -12,6 +12,11 @@
             app:showAsAction="never"
             />
         <item
+            android:id="@+id/action_exclude"
+            android:title="@string/exclude"
+            app:showAsAction="never"
+            />
+        <item
             android:id="@+id/action_rotate"
             android:orderInCategory="2"
             android:title="@string/rotate"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,7 @@
     <string name="auto_update_media_sub">You should disable in case of huge number of images.</string>
     <string name="traslucent_statusbar">Translucent Status Bar</string>
     <string name="traslucent_statusbar_sub">Apply a darker primary color to the notification bar.</string>
-    <string name="excluded_albums">Excluded Albums</string>
+    <string name="excluded_albums">Excluded Items</string>
     <string name="excluded_albums_sub">Restore the excluded albums.</string>
 
 


### PR DESCRIPTION
Motivation:
https://github.com/HoraApps/LeafPic/issues/277
Want to be able to not only exclude albums but also exclude individual pieces of media.

Implementation:
I have added a section in the SQLite store which keeps track of each album's excluded pieces of media. This store is consulted when media is displayed and is also altered when the user chooses to "exclude" the currently selected media. The user may select "exclude" from the album or from the media itself.

Let me know if you have any questions.
