### PR TITLE
Improve media Details Dialog

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/Activities/PhotoPagerActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/Activities/PhotoPagerActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -19,6 +20,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.Display;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.Surface;
@@ -28,6 +30,9 @@ import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
 import android.widget.EditText;
 import android.widget.RelativeLayout;
+import android.widget.TableLayout;
+import android.widget.TableRow;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
@@ -52,6 +57,7 @@ import com.mikepenz.google_material_typeface_library.GoogleMaterial;
 import com.yalantis.ucrop.UCrop;
 
 import java.io.File;
+import java.util.Map;
 
 /**
  * Created by dnld on 18/02/16.
@@ -125,13 +131,13 @@ public class PhotoPagerActivity extends SharedMediaActivity {
         setupSystemUI();
 
         getWindow().getDecorView().setOnSystemUiVisibilityChangeListener
-                                           (new View.OnSystemUiVisibilityChangeListener() {
-                                               @Override
-                                               public void onSystemUiVisibilityChange(int visibility) {
-                                                   if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) showSystemUI();
-                                                   else hideSystemUI();
-                                               }
-                                           });
+                (new View.OnSystemUiVisibilityChangeListener() {
+                    @Override
+                    public void onSystemUiVisibilityChange(int visibility) {
+                        if ((visibility & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) showSystemUI();
+                        else hideSystemUI();
+                    }
+                });
         adapter = new MediaPagerAdapter(getSupportFragmentManager(), getAlbum().getMedia());
 
         adapter.setVideoOnClickListener(new View.OnClickListener() {
@@ -139,7 +145,7 @@ public class PhotoPagerActivity extends SharedMediaActivity {
             public void onClick(View v) {
                 if (SP.getBoolean("set_internal_player", false)) {
                     Intent mpdIntent = new Intent(PhotoPagerActivity.this, PlayerActivity.class)
-                                               .setData(getAlbum().getCurrentMedia().getUri());
+                            .setData(getAlbum().getCurrentMedia().getUri());
                     startActivity(mpdIntent);
                 } else {
                     Intent intentOpenWith = new Intent(Intent.ACTION_VIEW);
@@ -255,7 +261,7 @@ public class PhotoPagerActivity extends SharedMediaActivity {
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(
-                                                                                    RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
+                RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE)
             params.setMargins(0,0,Measure.getNavigationBarSize(PhotoPagerActivity.this).x,0);
         else
@@ -447,7 +453,7 @@ public class PhotoPagerActivity extends SharedMediaActivity {
 
                             final AlertDialog.Builder passwordDialogBuilder = new AlertDialog.Builder(PhotoPagerActivity.this, getDialogStyle());
                             final EditText editTextPassword = securityObj.getInsertPasswordDialog
-                                                                                  (PhotoPagerActivity.this, passwordDialogBuilder);
+                                    (PhotoPagerActivity.this, passwordDialogBuilder);
 
                             passwordDialogBuilder.setPositiveButton(getString(R.string.ok_action), new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int which) {
@@ -462,7 +468,7 @@ public class PhotoPagerActivity extends SharedMediaActivity {
                             final AlertDialog passwordDialog = passwordDialogBuilder.create();
                             passwordDialog.show();
                             passwordDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View
-                                                                                                                 .OnClickListener() {
+                                    .OnClickListener() {
                                 @Override
                                 public void onClick(View v) {
                                     if (securityObj.checkPassword(editTextPassword.getText().toString())){
@@ -539,13 +545,14 @@ public class PhotoPagerActivity extends SharedMediaActivity {
 
             case R.id.action_details:
                 AlertDialog.Builder detailsDialogBuilder = new AlertDialog.Builder(PhotoPagerActivity.this, getDialogStyle());
-                AlertDialog detailsDialog =
+                final AlertDialog detailsDialog =
                         AlertDialogsHelper.getDetailsDialog(this, detailsDialogBuilder,getAlbum().getCurrentMedia());
 
                 detailsDialog.setButton(DialogInterface.BUTTON_POSITIVE, getString(R.string
-                                                                                           .ok_action), new DialogInterface.OnClickListener() {
+                        .ok_action), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) { }});
+
                 detailsDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getString(R.string.fix_date), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
@@ -553,6 +560,7 @@ public class PhotoPagerActivity extends SharedMediaActivity {
                             Toast.makeText(PhotoPagerActivity.this, R.string.unable_to_fix_date, Toast.LENGTH_SHORT).show();
                     }
                 });
+
                 detailsDialog.show();
                 break;
 

--- a/app/src/main/java/org/horaapps/leafpic/Data/Media.java
+++ b/app/src/main/java/org/horaapps/leafpic/Data/Media.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.ObjectInput;
 import java.io.Serializable;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
@@ -191,6 +192,11 @@ public class Media implements Parcelable, Serializable {
         return StringUtils.getPhotoNameByPath(path);
     }
 
+    public Map<String, Object> getAllDetails() {
+        loadMetadata();
+        return this.metadataMap;
+    }
+
     public GeoLocation getGeoLocation()  {
         try {
             Metadata metadata = ImageMetadataReader.readMetadata(new File(getPath()));
@@ -209,6 +215,7 @@ public class Media implements Parcelable, Serializable {
                         //Log.wtf("asd", tag.getTagName());
                     }
             } catch (Exception e){ e.printStackTrace(); }
+
         }
     }
     public long getSize() {

--- a/app/src/main/java/org/horaapps/leafpic/util/AlertDialogsHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/AlertDialogsHelper.java
@@ -1,11 +1,15 @@
 package org.horaapps.leafpic.util;
 
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.PorterDuff;
+import android.graphics.Typeface;
 import android.net.Uri;
 import android.support.annotation.StringRes;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
@@ -13,12 +17,15 @@ import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
+import android.widget.TableLayout;
+import android.widget.TableRow;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
 import com.drew.lang.GeoLocation;
 import org.horaapps.leafpic.Data.Media;
 import org.horaapps.leafpic.Activities.SettingsActivity;
+import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.Views.ThemedActivity;
 
 import java.lang.reflect.Field;
@@ -26,6 +33,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.horaapps.leafpic.SecretConstants.MAP_BOX_TOKEN;
 
@@ -96,9 +104,9 @@ public class AlertDialogsHelper {
         return progressDialog.create();
     }
 
-    public static AlertDialog getDetailsDialog(final ThemedActivity activity, AlertDialog.Builder detailsDialogBuilder, Media f) {
+    public static AlertDialog getDetailsDialog(final ThemedActivity activity, AlertDialog.Builder detailsDialogBuilder, final Media f) {
 
-        View dialogLayout = activity.getLayoutInflater().inflate(org.horaapps.leafpic.R.layout.dialog_media_detail, null);
+        final View dialogLayout = activity.getLayoutInflater().inflate(org.horaapps.leafpic.R.layout.dialog_media_detail, null);
 
         TextView textViewSize = (TextView) dialogLayout.findViewById(org.horaapps.leafpic.R.id.photo_size);
         TextView textViewType = (TextView) dialogLayout.findViewById(org.horaapps.leafpic.R.id.photo_type);
@@ -166,7 +174,7 @@ public class AlertDialogsHelper {
 
 
         final GeoLocation location;
-        if((location = f.getGeoLocation()) != null) {
+        if ((location = f.getGeoLocation()) != null) {
             PreferenceUtil SP = PreferenceUtil.getInstance(activity.getApplicationContext());
 
             String url;
@@ -174,28 +182,28 @@ public class AlertDialogsHelper {
                     SettingsActivity.GOOGLE_MAPS_PROVIDER)) {
                 case SettingsActivity.GOOGLE_MAPS_PROVIDER:
                 default:
-                    url = String.format(Locale.getDefault(),"http://maps.google.com/maps/api/staticmap" +
-                        "?center=%f,%f&zoom=15&size=500x300&scale=2&sensor=false", location.getLatitude(), location.getLongitude());
+                    url = String.format(Locale.getDefault(), "http://maps.google.com/maps/api/staticmap" +
+                            "?center=%f,%f&zoom=15&size=500x300&scale=2&sensor=false", location.getLatitude(), location.getLongitude());
                     break;
                 case SettingsActivity.OSM_MAP_BOX:
-                    url = String.format(Locale.getDefault(),"https://api.mapbox.com/v4/mapbox.streets/%f,%f,15/500x300.jpg?access_token=%s",
-                            location.getLongitude(),location.getLatitude(), MAP_BOX_TOKEN);
+                    url = String.format(Locale.getDefault(), "https://api.mapbox.com/v4/mapbox.streets/%f,%f,15/500x300.jpg?access_token=%s",
+                            location.getLongitude(), location.getLatitude(), MAP_BOX_TOKEN);
 
                     break;
                 case SettingsActivity.OSM_MAP_BOX_DARK:
-                    url = String.format(Locale.getDefault(),"https://api.mapbox.com/v4/mapbox.dark/%f,%f,15/500x300.jpg?access_token=%s",
-                            location.getLongitude(),location.getLatitude(), MAP_BOX_TOKEN);
+                    url = String.format(Locale.getDefault(), "https://api.mapbox.com/v4/mapbox.dark/%f,%f,15/500x300.jpg?access_token=%s",
+                            location.getLongitude(), location.getLatitude(), MAP_BOX_TOKEN);
 
                     break;
                 case SettingsActivity.OSM_MAP_BOX_LIGHT:
-                    url = String.format(Locale.getDefault(),"https://api.mapbox.com/v4/mapbox.light/%f,%f,15/500x300.jpg?access_token=%s",
-                            location.getLongitude(),location.getLatitude(), MAP_BOX_TOKEN);
+                    url = String.format(Locale.getDefault(), "https://api.mapbox.com/v4/mapbox.light/%f,%f,15/500x300.jpg?access_token=%s",
+                            location.getLongitude(), location.getLatitude(), MAP_BOX_TOKEN);
 
                     break;
                 case SettingsActivity.OSM_TYLER_PROVIDER:
-                    url = String.format(Locale.getDefault(),"https://tyler-demo.herokuapp.com/" +
-                        "?greyscale=false&lat=%f&lon=%f&zoom=15&width=500&height=300" +
-                        "&tile_url=http://[abcd].tile.stamen.com/watercolor/{zoom}/{x}/{y}.jpg", location.getLatitude(), location.getLongitude());
+                    url = String.format(Locale.getDefault(), "https://tyler-demo.herokuapp.com/" +
+                            "?greyscale=false&lat=%f&lon=%f&zoom=15&width=500&height=300" +
+                            "&tile_url=http://[abcd].tile.stamen.com/watercolor/{zoom}/{x}/{y}.jpg", location.getLatitude(), location.getLongitude());
 
                     break;
             }
@@ -227,17 +235,55 @@ public class AlertDialogsHelper {
         long dateTake = f.getDateTaken();
         if (dateTake != -1) {
             Calendar c = Calendar.getInstance(), c2 = Calendar.getInstance();
-            c.setTimeInMillis(dateTake); c2.setTimeInMillis(f.getDateModified());
+            c.setTimeInMillis(dateTake);
+            c2.setTimeInMillis(f.getDateModified());
             if (!(c.get(Calendar.YEAR) == c2.get(Calendar.YEAR)) && !(c.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR))) {
                 textViewDateTaken.setText(SimpleDateFormat.getDateTimeInstance().format(new Date(dateTake)));
                 dialogLayout.findViewById(org.horaapps.leafpic.R.id.ll_date_taken).setVisibility(View.VISIBLE);
             }
         }
+
+
+
+        final TextView showMoreText = (TextView) dialogLayout.findViewById(R.id.details_showmore);
+        showMoreText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                showMoreDetails(dialogLayout, activity, f);
+                showMoreText.setVisibility(View.INVISIBLE);
+            }
+        });
+
         ((CardView) dialogLayout.findViewById(org.horaapps.leafpic.R.id.photo_details_card)).setCardBackgroundColor(activity.getCardBackgroundColor());
         detailsDialogBuilder.setView(dialogLayout);
-
         return detailsDialogBuilder.create();
     }
 
+    static void showMoreDetails(View dialogLayout, ThemedActivity activity, Media media) {
+        Map<String, Object> metadata = media.getAllDetails();
+        TableLayout detailsTable = (TableLayout) dialogLayout.findViewById(R.id.ll_detail_dialog);
+        float scale = activity.getResources().getDisplayMetrics().density;
+        int tenPxInDp = (int) (10 * scale + 0.5f);
 
+        for (String metadataKey : metadata.keySet()) {
+            TableRow row = new TableRow(activity.getApplicationContext());
+
+            TextView metaDataKey = new TextView(activity.getApplicationContext());
+            TextView metaDataValue = new TextView(activity.getApplicationContext());
+            metaDataKey.setText(metadataKey);
+            metaDataKey.setLayoutParams(new TableRow.LayoutParams(TableRow.LayoutParams.WRAP_CONTENT, TableRow.LayoutParams.WRAP_CONTENT));
+            metaDataValue.setText(metadata.get(metadataKey).toString());
+            metaDataValue.setLayoutParams(new TableRow.LayoutParams(TableRow.LayoutParams.WRAP_CONTENT, TableRow.LayoutParams.WRAP_CONTENT));
+            metaDataKey.setTextColor(activity.getTextColor());
+            metaDataKey.setTypeface(null, Typeface.BOLD);
+            metaDataKey.setGravity(Gravity.END);
+            metaDataValue.setTextColor(activity.getTextColor());
+            metaDataValue.setTextSize(16);
+            metaDataValue.setPaddingRelative(tenPxInDp, 0, 0, 0);
+            row.addView(metaDataKey);
+            row.addView(metaDataValue);
+            detailsTable.addView(row, new TableLayout.LayoutParams(TableLayout.LayoutParams.MATCH_PARENT, TableLayout.LayoutParams.WRAP_CONTENT));
+        }
+
+    }
 }

--- a/app/src/main/java/org/horaapps/leafpic/util/AlertDialogsHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/AlertDialogsHelper.java
@@ -243,8 +243,6 @@ public class AlertDialogsHelper {
             }
         }
 
-
-
         final TextView showMoreText = (TextView) dialogLayout.findViewById(R.id.details_showmore);
         showMoreText.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/res/layout/dialog_media_detail.xml
+++ b/app/src/main/res/layout/dialog_media_detail.xml
@@ -329,7 +329,7 @@
             android:layout_width="match_parent"
             android:id="@+id/details_showmore"
             android:layout_below="@id/details_scrollview"
-            android:text="Show More"
+            android:text="@string/show_more"
             android:textSize="16dp"
             android:textColor="@color/accent_blue"
             android:gravity="center"

--- a/app/src/main/res/layout/dialog_media_detail.xml
+++ b/app/src/main/res/layout/dialog_media_detail.xml
@@ -7,14 +7,11 @@
     app:cardCornerRadius="2dp"
     android:id="@+id/photo_details_card"
 >
-    <ScrollView
+
+
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <RelativeLayout
-            android:id="@+id/rl_photo_details"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            >
 
             <RelativeLayout
                 android:id="@+id/header_photo_details"
@@ -39,10 +36,21 @@
                     android:textSize="18sp"
                     android:textStyle="bold"
                     />
-
             </RelativeLayout>
 
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/details_scrollview"
+            android:layout_below="@id/header_photo_details">
 
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
 
             <TableLayout
                 android:id="@+id/ll_detail_dialog"
@@ -51,8 +59,7 @@
                 android:paddingTop="10dp"
                 android:paddingLeft="10dp"
                 android:paddingRight="10dp"
-                android:orientation="vertical"
-                android:layout_below="@id/header_photo_details">
+                android:orientation="vertical">
 
                 <!--PATH-->
                 <TableRow
@@ -314,6 +321,21 @@
                 >
 
             </LinearLayout>-->
-        </RelativeLayout>
-    </ScrollView>
+            </LinearLayout>
+            </HorizontalScrollView>
+     </ScrollView>
+        <TextView
+            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:id="@+id/details_showmore"
+            android:layout_below="@id/details_scrollview"
+            android:text="Show More"
+            android:textSize="16dp"
+            android:textColor="@color/accent_blue"
+            android:gravity="center"
+            android:paddingBottom="10dp"
+            android:paddingTop="10dp">
+        </TextView>
+
+    </RelativeLayout>
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="rename_album">Rename album</string>
     <string name="details">Details</string>
     <string name="more">More</string>
+    <string name="show_more">Show More</string>
     <string name="edit_with">Edit with</string>
     <string name="open_with">Open with</string>
     <string name="upload">Upload</string>


### PR DESCRIPTION
### Fixes issues:

https://github.com/HoraApps/LeafPic/issues/192
### Motivation:

When viewing the details for an image, users may want to see more details than the few details that were picked for them. 
### Implementation

I added a "show more" button that expands the details dialog and allows the user to see the entire details dataset for their media. I also rearranged the details dialog so that it is more easily scrollable (The title bar no longer scrolls and the user may now scroll horizontally)
### Followups:
1. When the user clicks "Show More", we may want to remove the original details shown.
2. When a user clicks "Show More" the `TableView` that shows the details is skewed because of alignments of the columns. We may want to think about displaying the data differently.
3. ~~Currently, the "Show More" string is not in an XML file (not ready for translation)~~
4. The creation of the details dialog should be refactored.. it's a little messy ;)
