### PR TITLE
Refreshing the settings activity & introducing `Themeable` pattern

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ android {
     }
 }
 
-project.ext.supportLib = "25.0.1"
+project.ext.supportLib = "25.2.0"
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
@@ -78,4 +78,8 @@ dependencies {
     compile 'com.github.Commit451:bypasses:1.0.4'
 
     compile 'com.github.jetradarmobile:desertplaceholder:1.1.1'
+
+    //Butter Knife
+    compile 'com.jakewharton:butterknife:8.5.1'
+    annotationProcessor 'com.jakewharton:butterknife-compiler:8.5.1'
 }

--- a/app/src/main/java/org/horaapps/leafpic/activities/AboutActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/AboutActivity.java
@@ -4,6 +4,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.Toolbar;
@@ -207,8 +208,10 @@ public class AboutActivity extends ThemedActivity {
         ((TextView) findViewById(R.id.about_version_item_sub)).setText(BuildConfig.VERSION_NAME);
     }
 
+    @CallSuper
     @Override
     public void updateUiElements() {
+        super.updateUiElements();
         toolbar.setBackgroundColor(getPrimaryColor());
         toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_arrow_back));
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/org/horaapps/leafpic/activities/BlackWhiteListActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/BlackWhiteListActivity.java
@@ -3,6 +3,7 @@ package org.horaapps.leafpic.activities;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.GridLayoutManager;
@@ -163,8 +164,10 @@ public class BlackWhiteListActivity extends SharedMediaActivity {
         mRecyclerView.setItemAnimator(new DefaultItemAnimator());
     }
 
+    @CallSuper
     @Override
     public void updateUiElements(){
+        super.updateUiElements();
         toolbar.setBackgroundColor(getPrimaryColor());
         mRecyclerView.setBackgroundColor(getBackgroundColor());
         setStatusBarColor();

--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -14,6 +14,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.MediaStore;
+import android.support.annotation.CallSuper;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -420,9 +421,10 @@ public class MainActivity extends SharedMediaActivity {
         }).start();
     }
 
+    @CallSuper
     @Override
     public void updateUiElements() {
-
+        super.updateUiElements();
         //TODO: MUST BE FIXED
         toolbar.setPopupTheme(getPopupToolbarStyle());
         toolbar.setBackgroundColor(getPrimaryColor());

--- a/app/src/main/java/org/horaapps/leafpic/activities/PlayerActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/PlayerActivity.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
@@ -483,8 +484,10 @@ public class PlayerActivity extends ThemedActivity implements  ExoPlayer.EventLi
 
     /**** THEMING STUFF ****/
 
+    @CallSuper
     @Override
     public void updateUiElements() {
+        super.updateUiElements();
         toolbar.setBackgroundColor(getPrimaryColor());
         setStatusBarColor();
         setNavBarColor();

--- a/app/src/main/java/org/horaapps/leafpic/activities/SecurityActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SecurityActivity.java
@@ -3,6 +3,7 @@ package org.horaapps.leafpic.activities;
 import android.content.DialogInterface;
 import android.graphics.PorterDuff;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.SwitchCompat;
@@ -167,8 +168,10 @@ public class SecurityActivity extends ThemedActivity {
     }
 
 
+    @CallSuper
     @Override
     public void updateUiElements() {
+        super.updateUiElements();
         setRecentApp(getString(R.string.security));
         toolbar.setBackgroundColor(getPrimaryColor());
 

--- a/app/src/main/java/org/horaapps/leafpic/activities/SettingsActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SettingsActivity.java
@@ -1,23 +1,17 @@
 package org.horaapps.leafpic.activities;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
-import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.widget.CardView;
-import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
-import android.view.KeyCharacterMap;
-import android.view.KeyEvent;
 import android.view.View;
-import android.view.ViewConfiguration;
 import android.widget.ScrollView;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
-import com.mikepenz.iconics.view.IconicsImageView;
 
 import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.activities.base.ThemedActivity;
@@ -29,342 +23,43 @@ import org.horaapps.leafpic.settings.SinglePhotoSetting;
 import org.horaapps.leafpic.util.ColorPalette;
 import org.horaapps.leafpic.util.PreferenceUtil;
 import org.horaapps.leafpic.util.Security;
+import org.horaapps.leafpic.util.ViewUtil;
+import org.horaapps.leafpic.views.SettingWithSwitchView;
 
-/**
- * Created by Jibo on 02/03/2016.
- */
-@SuppressWarnings("ResourceAsColor")
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import butterknife.Unbinder;
+
 public class SettingsActivity extends ThemedActivity {
-
     private PreferenceUtil SP;
-
     private Toolbar toolbar;
-    private ScrollView scr;
 
-    private TextView txtGT;
-    private TextView txtTT;
-    private TextView txtPT;
-    private TextView txtVT;
-    private TextView txtAT;
+    @BindView(R.id.option_max_brightness) SettingWithSwitchView optionMaxBrightness;
+    @BindView(R.id.option_picture_orientation) SettingWithSwitchView optionOrientation;
+    @BindView(R.id.option_full_resolution) SettingWithSwitchView optionDelayFullRes;
 
-    private SwitchCompat swNavBar;
-    private SwitchCompat swStatusBar;
-    private SwitchCompat swMaxLuminosity;
-    private SwitchCompat swPictureOrientation;
-    private SwitchCompat swDelayFullImage;
+    @BindView(R.id.option_auto_update_media) SettingWithSwitchView optionAutoUpdateMedia;
+    @BindView(R.id.option_include_video) SettingWithSwitchView optionIncludeVideo;
+    @BindView(R.id.option_swipe_direction) SettingWithSwitchView optionSwipeDirection;
 
-    private SwitchCompat swAutoUpdate;
-    private SwitchCompat swIncludeVideo;
-    private SwitchCompat swSwipeDirection;
-    private SwitchCompat swShowFab;
-    private SwitchCompat swSubScaling;
+    @BindView(R.id.option_fab) SettingWithSwitchView optionShowFab;
+    @BindView(R.id.option_statusbar) SettingWithSwitchView optionStatusbar;
+    @BindView(R.id.option_colored_navbar) SettingWithSwitchView optionColoredNavbar;
 
+    @BindView(R.id.option_sub_scaling) SettingWithSwitchView optionSubScaling;
+
+    private Unbinder unbinder;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_settings);
-        toolbar = (Toolbar) findViewById(R.id.toolbar);
         SP = PreferenceUtil.getInstance(getApplicationContext());
 
-        txtTT = (TextView) findViewById(R.id.theme_setting_title);
-        txtGT = (TextView) findViewById(R.id.general_setting_title);
-        txtPT = (TextView) findViewById(R.id.picture_setting_title);
-        txtVT = (TextView) findViewById(R.id.video_setting_title);
-        txtAT = (TextView) findViewById(R.id.advanced_setting_title);
+        unbinder = ButterKnife.bind(this);
+        toolbar = (Toolbar) findViewById(R.id.toolbar);
 
-        scr = (ScrollView)findViewById(R.id.settingAct_scrollView);
-
-        initUi();
-
-        /*** BASIC THEME ***/
-        findViewById(R.id.ll_basic_theme).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new ColorsSetting(SettingsActivity.this, SP).chooseBaseTheme();
-            }
-        });
-
-        /*** CARD VIEW STYLE ***/
-        findViewById(R.id.ll_card_view_style).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new CardViewStyleSetting(SettingsActivity.this, SP).show();
-            }
-        });
-
-        /*** SECURITY ***/
-        findViewById(R.id.ll_security).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if(Security.isPasswordSet(getApplicationContext()))
-                    askPasswordDialog();
-                else startActivity(new Intent(getApplicationContext(), SecurityActivity.class));
-            }
-        });
-
-        /*** PRIMARY COLOR PIKER ***/
-        findViewById(R.id.ll_primaryColor).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new ColorsSetting(SettingsActivity.this, SP).chooseColor(R.string.primary_color, new ColorsSetting.ColorChooser() {
-                    @Override
-                    public void onColorSelected(int color) {
-                        SP.putInt(getString(R.string.preference_primary_color), color);
-                        updateViewsWithPrimaryColor(color);
-                    }
-
-                    @Override
-                    public void onDialogDismiss() {
-                        updateViewsWithPrimaryColor(getPrimaryColor());
-                    }
-
-                    @Override
-                    public void onColorChanged(int color) {
-                        updateViewsWithPrimaryColor(color);
-                    }
-                }, getPrimaryColor());
-            }
-        });
-
-        /*** ACCENT COLOR PIKER ***/
-        findViewById(R.id.ll_accentColor).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new ColorsSetting(SettingsActivity.this, SP).chooseColor(R.string.accent_color, new ColorsSetting.ColorChooser() {
-                    @Override
-                    public void onColorSelected(int color) {
-                        SP.putInt(getString(R.string.preference_accent_color), color);
-                        updateViewsWithAccentColor(color);
-                    }
-
-                    @Override
-                    public void onDialogDismiss() {
-                        updateViewsWithAccentColor(getAccentColor());
-                    }
-
-                    @Override
-                    public void onColorChanged(int color) {
-                        updateViewsWithAccentColor(color);
-                    }
-                }, getAccentColor());
-            }
-        });
-
-        /*** EXCLUDED ALBUMS INTENT ***/
-        findViewById(R.id.ll_white_list).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startActivity(new Intent(getApplicationContext(), BlackWhiteListActivity.class));
-            }
-        });
-
-        /*** CUSTOMIZE PICTURE VIEWER DIALOG ***/
-        findViewById(R.id.ll_custom_thirdAct).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new SinglePhotoSetting(SettingsActivity.this, SP).show();
-            }
-        });
-
-        /*** MAP PROVIDER DIALOG ***/
-        findViewById(R.id.ll_map_provider).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new MapProviderSetting(SettingsActivity.this, SP).choseProvider();
-            }
-        });
-
-        /*** MULTI COLUMN DIALOG ***/
-        findViewById(R.id.ll_n_columns).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                new GeneralSetting(SettingsActivity.this, SP).editNumberOfColumns();
-            }
-        });
-
-        /*** SW Show Fab ***/
-        swShowFab = (SwitchCompat) findViewById(R.id.sw_show_fab);
-        swShowFab.setChecked(SP.getBoolean(getString(R.string.preference_show_fab), false));
-        swShowFab.setClickable(false);
-        findViewById(R.id.ll_fab_options).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swShowFab.setChecked(!swShowFab.isChecked());
-                SP.putBoolean(getString(R.string.preference_show_fab), swShowFab.isChecked());
-                setSwitchColor(getAccentColor(), swShowFab);
-            }
-        });
-
-        /*** SW Show Fab ***/
-        swSubScaling = (SwitchCompat) findViewById(R.id.sw_sub_scaling);
-        swSubScaling.setChecked(SP.getBoolean(getString(R.string.preference_sub_scaling), false));
-        swSubScaling.setClickable(false);
-        findViewById(R.id.ll_sub_scaling).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swSubScaling.setChecked(!swSubScaling.isChecked());
-                SP.putBoolean(getString(R.string.preference_sub_scaling), swSubScaling.isChecked());
-                setSwitchColor(getAccentColor(), swSubScaling);
-            }
-        });
-
-        /*** SW INCLUDE VIDEO ***/
-        swIncludeVideo = (SwitchCompat) findViewById(R.id.set_include_video);
-        swIncludeVideo.setChecked(SP.getBoolean(getString(R.string.preference_include_video), true));
-        swIncludeVideo.setClickable(false);
-        findViewById(R.id.ll_switch_include_video).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swIncludeVideo.setChecked(!swIncludeVideo.isChecked());
-                SP.putBoolean(getString(R.string.preference_include_video), swIncludeVideo.isChecked());
-                setSwitchColor(getAccentColor(), swIncludeVideo);
-            }
-        });
-
-        /*** SW SWIPE DIRECTION ***/
-        swSwipeDirection = (SwitchCompat) findViewById(R.id.Set_media_viewer_swipe_direction);
-        swSwipeDirection.setChecked(SP.getBoolean(getString(R.string.preference_swipe_direction_inverted), false));
-        swSwipeDirection.setClickable(false);
-        findViewById(R.id.ll_media_viewer_swipe_direction).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swSwipeDirection.setChecked(!swSwipeDirection.isChecked());
-                SP.putBoolean(getString(R.string.preference_swipe_direction_inverted), swSwipeDirection.isChecked());
-                setSwitchColor(getAccentColor(), swSwipeDirection);
-            }
-        });
-
-        /*** SW AUTO UPDATE MEDIA ***/
-        swAutoUpdate = (SwitchCompat) findViewById(R.id.SetAutoUpdateMedia);
-        swAutoUpdate.setChecked(SP.getBoolean(getString(R.string.preference_auto_update_media), false));
-        swAutoUpdate.setClickable(false);
-        findViewById(R.id.ll_auto_update_media).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swAutoUpdate.setChecked(!swAutoUpdate.isChecked());
-                SP.putBoolean(getString(R.string.preference_auto_update_media), swAutoUpdate.isChecked());
-                setSwitchColor(getAccentColor(), swAutoUpdate);
-            }
-        });
-
-        /*** SW DELAY FULL-SIZE IMAGE ***/
-        swDelayFullImage = (SwitchCompat) findViewById(R.id.set_full_resolution);
-        swDelayFullImage.setChecked(SP.getBoolean(getString(R.string.preference_delay_full_image), true));
-        swDelayFullImage.setClickable(false);
-        findViewById(R.id.ll_switch_full_resolution).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swDelayFullImage.setChecked(!swDelayFullImage.isChecked());
-                SP.putBoolean(getString(R.string.preference_delay_full_image), swDelayFullImage.isChecked());
-                setSwitchColor(getAccentColor(), swDelayFullImage);
-            }
-        });
-
-        /*** SW PICTURE ORIENTATION ***/
-        swPictureOrientation = (SwitchCompat) findViewById(R.id.set_picture_orientation);
-        swPictureOrientation.setChecked(SP.getBoolean(getString(R.string.preference_auto_rotate), false));
-        swPictureOrientation.setClickable(false);
-        findViewById(R.id.ll_switch_picture_orientation).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swPictureOrientation.setChecked(!swPictureOrientation.isChecked());
-                SP.putBoolean(getString(R.string.preference_auto_rotate), swPictureOrientation.isChecked());
-                setSwitchColor(getAccentColor(), swPictureOrientation);
-            }
-        });
-
-        /*** SW MAX LUMINOSITY ***/
-        swMaxLuminosity = (SwitchCompat) findViewById(R.id.set_max_luminosity);
-        swMaxLuminosity.setChecked(SP.getBoolean(getString(R.string.preference_max_brightness), false));
-        swMaxLuminosity.setClickable(false);
-        findViewById(R.id.ll_switch_max_luminosity).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swMaxLuminosity.setChecked(!swMaxLuminosity.isChecked());
-                SP.putBoolean(getString(R.string.preference_max_brightness), swMaxLuminosity.isChecked());
-                setSwitchColor(getAccentColor(), swMaxLuminosity);
-            }
-        });
-
-        /*** SW TRANSLUCENT STATUS BAR ***/
-        swStatusBar = (SwitchCompat) findViewById(R.id.SetTraslucentStatusBar);
-        swStatusBar.setChecked(SP.getBoolean(getString(R.string.preference_translucent_status_bar), true));
-        swStatusBar.setClickable(false);
-        findViewById(R.id.ll_switch_TraslucentStatusBar).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swStatusBar.setChecked(!swStatusBar.isChecked());
-                SP.putBoolean(getString(R.string.preference_translucent_status_bar), swStatusBar.isChecked());
-                updateTheme();
-                setStatusBarColor();
-                setSwitchColor(getAccentColor(), swStatusBar);
-            }
-        });
-
-        /*** SW COLORED NAV BAR ***/
-        swNavBar = (SwitchCompat) findViewById(R.id.SetColoredNavBar);
-        swNavBar.setChecked(SP.getBoolean(getString(R.string.preference_colored_nav_bar), false));
-        swNavBar.setClickable(false);
-        findViewById(R.id.ll_switch_ColoredNavBar).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swNavBar.setChecked(!swNavBar.isChecked());
-                SP.putBoolean(getString(R.string.preference_colored_nav_bar), swNavBar.isChecked());
-                updateTheme();
-                setSwitchColor(getAccentColor(), swNavBar);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                    getWindow().setNavigationBarColor(isNavigationBarColored() ? getPrimaryColor() : ContextCompat.getColor(getApplicationContext(), R.color.md_black_1000));
-
-            }
-        });
-    }
-
-    private void askPasswordDialog() {
-
-        Security.askPassword(SettingsActivity.this, new Security.PasswordInterface() {
-            @Override
-            public void onSuccess() {
-                startActivity(new Intent(getApplicationContext(), SecurityActivity.class));
-            }
-
-            @Override
-            public void onError() {
-                Toast.makeText(getApplicationContext(), R.string.wrong_password, Toast.LENGTH_SHORT).show();
-            }
-        });
-    }
-
-    public void updateViewsWithAccentColor(int color){
-        setTextViewColor(color, txtAT, txtGT, txtPT, txtTT, txtVT);
-        setSwitchColor(color,
-                swDelayFullImage,
-                swNavBar,
-                swStatusBar,
-                swMaxLuminosity,
-                swPictureOrientation,
-                swAutoUpdate,
-                swIncludeVideo,
-                swSwipeDirection,
-                swShowFab,
-                swSubScaling);
-    }
-
-    public void updateViewsWithPrimaryColor(int color){
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (isTranslucentStatusBar()) {
-                getWindow().setStatusBarColor(ColorPalette.getObscuredColor(color));
-            } else getWindow().setStatusBarColor(color);
-            if (isNavigationBarColored())
-                getWindow().setNavigationBarColor(color);
-            else
-                getWindow().setNavigationBarColor(ContextCompat.getColor(this, R.color.md_black_1000));
-        }
-        toolbar.setBackgroundColor(color);
-        setScrollViewColor(scr);
-    }
-
-    private void initUi() {
         setSupportActionBar(toolbar);
         toolbar.setNavigationIcon(getToolbarIcon(GoogleMaterial.Icon.gmd_arrow_back));
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
@@ -373,113 +68,154 @@ public class SettingsActivity extends ThemedActivity {
                 onBackPressed();
             }
         });
+
+        optionStatusbar.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                updateTheme();
+                setStatusBarColor();
+            }
+        });
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (ViewUtil.hasNavBar(this)) {
+                optionColoredNavbar.setOnClickListener(new View.OnClickListener() {
+                    @SuppressLint("NewApi")
+                    @Override
+                    public void onClick(View view) {
+                        updateTheme();
+                        getWindow().setNavigationBarColor(isNavigationBarColored() ? getPrimaryColor() : ContextCompat.getColor(getApplicationContext(), R.color.md_black_1000));
+                    }
+                });
+            } else optionColoredNavbar.setVisibility(View.GONE);
+        }
+        ScrollView scrollView = ButterKnife.findById(this, R.id.settingAct_scrollView);
+        setScrollViewColor(scrollView);
     }
 
-
-
     @Override
-    public void updateUiElements(){
+    protected void onDestroy() {
+        if (unbinder != null) unbinder.unbind();
+        super.onDestroy();
+    }
 
-        /** BackGround **/
+    @CallSuper
+    @Override
+    public void updateUiElements() {
+        super.updateUiElements();
         findViewById(org.horaapps.leafpic.R.id.setting_background).setBackgroundColor(getBackgroundColor());
-
-        /** Cards **/
-        int color = getCardBackgroundColor();
-        ((CardView) findViewById(org.horaapps.leafpic.R.id.general_setting_card)).setCardBackgroundColor(color);
-        ((CardView) findViewById(org.horaapps.leafpic.R.id.theme_setting_card)).setCardBackgroundColor(color);
-        ((CardView) findViewById(org.horaapps.leafpic.R.id.preview_picture_setting_card)).setCardBackgroundColor(color);
-        ((CardView) findViewById(org.horaapps.leafpic.R.id.video_setting_card)).setCardBackgroundColor(color);
-        ((CardView) findViewById(R.id.advanced_setting_card)).setCardBackgroundColor(color);
-
-        toolbar.setBackgroundColor(getPrimaryColor());
         setStatusBarColor();
         setNavBarColor();
         setRecentApp(getString(org.horaapps.leafpic.R.string.settings));
-        setScrollViewColor(scr);
-        updateViewsWithAccentColor(getAccentColor());
 
-        /** Icons **/
-        color = getIconColor();
-        ((IconicsImageView) findViewById(R.id.ll_switch_picture_orientation_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.ll_switch_max_luminosity_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.ll_switch_full_resolution_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.traslucent_statusbar_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.custom_3thact_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.primary_color_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.accent_color_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.basic_theme_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.n_columns_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.nav_bar_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.white_list_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.internal_include_video)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.auto_update_media_Icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.security_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.fab_options_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.sub_scaling_Icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.map_provider_icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.media_viewer_swipe_direction_Icon)).setColor(color);
-        ((IconicsImageView) findViewById(R.id.card_view_style_icon)).setColor(color);
-
-        /** TextViews **/
-        color = getTextColor();
-        ((TextView) findViewById(R.id.max_luminosity_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.full_resolution_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.picture_orientation_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.custom_3thAct_title)).setTextColor(color);
-        ((TextView) findViewById(R.id.Traslucent_StatusBar_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.PrimaryColor_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.accentColor_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.basic_theme_item)).setTextColor(color);
-        ((TextView) findViewById(R.id.n_columns_Item_Title)).setTextColor(color);
-        ((TextView) findViewById(R.id.NavBar_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.sub_scaling_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.white_list_item_title)).setTextColor(color);
-        ((TextView) findViewById(R.id.include_video_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.auto_update_media_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.security_item_title)).setTextColor(color);
-        ((TextView) findViewById(R.id.fab_options_item_title)).setTextColor(color);
-        ((TextView) findViewById(R.id.map_provider_item_title)).setTextColor(color);
-        ((TextView) findViewById(R.id.media_viewer_swipe_direction_Item)).setTextColor(color);
-        ((TextView) findViewById(R.id.card_view_style_title)).setTextColor(color);
-
-        /** Sub Text Views**/
-        color = getSubTextColor();
-        ((TextView) findViewById(R.id.max_luminosity_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.full_resolution_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.custom_3thAct_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.picture_orientation_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.Traslucent_StatusBar_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.PrimaryColor_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.accentColor_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.basic_theme_item_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.n_columns_Item_Title_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.NavBar_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.white_list_item_title_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.sub_scaling_Item_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.include_video_Item_Sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.auto_update_media_Item_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.security_item_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.fab_options_item_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.map_provider_item_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.media_viewer_swipe_direction_sub)).setTextColor(color);
-        ((TextView) findViewById(R.id.card_view_style_Sub)).setTextColor(color);
-
-        //LIMITED OPTIONS
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            findViewById(R.id.ll_switch_TraslucentStatusBar).setVisibility(View.VISIBLE);
-            if(hasNavBar()) findViewById(R.id.ll_switch_ColoredNavBar).setVisibility(View.VISIBLE);
+            int color = getThemeHelper().getPrimaryColor();
+            if (isTranslucentStatusBar()) getWindow().setStatusBarColor(ColorPalette.getObscuredColor(color));
+            else getWindow().setStatusBarColor(color);
+            if (isNavigationBarColored()) getWindow().setNavigationBarColor(color);
+            else getWindow().setNavigationBarColor(ContextCompat.getColor(this, R.color.md_black_1000));
         }
     }
 
-    private boolean hasNavBar() {
-        Resources resources = getResources();
-        int id = resources.getIdentifier("config_showNavigationBar", "bool", "android");
-        if (id > 0) {
-            return resources.getBoolean(id);
-        } else {    // Check for keys
-            boolean hasMenuKey = ViewConfiguration.get(this).hasPermanentMenuKey();
-            boolean hasBackKey = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK);
-            return !hasMenuKey && !hasBackKey;
-        }
+    @OnClick(R.id.ll_basic_theme)
+    public void onChangeThemeClicked(View view) {
+        new ColorsSetting(SettingsActivity.this, SP).chooseBaseTheme();
     }
+
+    @OnClick(R.id.ll_card_view_style)
+    public void onChangeCardViewStyleClicked(View view) {
+        new CardViewStyleSetting(SettingsActivity.this, SP).show();
+    }
+
+    @OnClick(R.id.ll_security)
+    public void onSecurityClicked(View view) {
+        if (Security.isPasswordSet(getApplicationContext())) {
+            Security.askPassword(SettingsActivity.this, new Security.PasswordInterface() {
+                @Override
+                public void onSuccess() {
+                    startActivity(new Intent(getApplicationContext(), SecurityActivity.class));
+                }
+
+                @Override
+                public void onError() {
+                    Toast.makeText(getApplicationContext(), R.string.wrong_password, Toast.LENGTH_SHORT).show();
+                }
+            });
+        } else startActivity(new Intent(getApplicationContext(), SecurityActivity.class));
+    }
+
+    @OnClick(R.id.ll_primaryColor)
+    public void onChangePrimaryColorClicked(View view) {
+        final int originalColor = getPrimaryColor();
+        new ColorsSetting(SettingsActivity.this, SP).chooseColor(R.string.primary_color, new ColorsSetting.ColorChooser() {
+            @Override
+            public void onColorSelected(int color) {
+                SP.putInt(getString(R.string.preference_primary_color), color);
+                updateTheme();
+                updateUiElements();
+            }
+
+            @Override
+            public void onDialogDismiss() {
+                SP.putInt(getString(R.string.preference_primary_color), originalColor);
+                updateTheme();
+                updateUiElements();
+            }
+
+            @Override
+            public void onColorChanged(int color) {
+                SP.putInt(getString(R.string.preference_primary_color), color);
+                updateTheme();
+                updateUiElements();
+            }
+        }, getPrimaryColor());
+    }
+
+    @OnClick(R.id.ll_accentColor)
+    public void onChangeAccentColorClicked(View view) {
+        final int originalColor = getAccentColor();
+        new ColorsSetting(SettingsActivity.this, SP).chooseColor(R.string.accent_color, new ColorsSetting.ColorChooser() {
+            @Override
+            public void onColorSelected(int color) {
+                SP.putInt(getString(R.string.preference_accent_color), color);
+                updateTheme();
+                updateUiElements();
+            }
+
+            @Override
+            public void onDialogDismiss() {
+                SP.putInt(getString(R.string.preference_accent_color), originalColor);
+                updateTheme();
+                updateUiElements();
+            }
+
+            @Override
+            public void onColorChanged(int color) {
+                SP.putInt(getString(R.string.preference_accent_color), color);
+                updateTheme();
+                updateUiElements();
+            }
+        }, getAccentColor());
+    }
+
+    @OnClick(R.id.ll_white_list)
+    public void onWhiteListClicked(View view) {
+        startActivity(new Intent(getApplicationContext(), BlackWhiteListActivity.class));
+    }
+
+    @OnClick(R.id.ll_custom_thirdAct)
+    public void onCustomThirdActClicked(View view) {
+        new SinglePhotoSetting(SettingsActivity.this, SP).show();
+    }
+
+    @OnClick(R.id.ll_map_provider)
+    public void onMapProviderClicked(View view) {
+        new MapProviderSetting(SettingsActivity.this, SP).choseProvider();
+    }
+
+    @OnClick(R.id.ll_n_columns)
+    public void onChangeColumnsClicked(View view) {
+        new GeneralSetting(SettingsActivity.this, SP).editNumberOfColumns();
+    }
+
 }

--- a/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
@@ -178,7 +179,9 @@ public class SingleMediaActivity extends SharedMediaActivity {
         }
     }
 
+    @CallSuper
     public void updateUiElements() {
+        super.updateUiElements();
         /**** Theme ****/
         toolbar = (Toolbar) findViewById(R.id.toolbar);
         activityBackground = (RelativeLayout) findViewById(R.id.PhotoPager_Layout);

--- a/app/src/main/java/org/horaapps/leafpic/activities/SplashScreen.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SplashScreen.java
@@ -11,6 +11,7 @@ import android.graphics.PorterDuff;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
@@ -149,8 +150,10 @@ public class SplashScreen extends SharedMediaActivity {
         }
     }
 
+    @CallSuper
     @Override
     public void updateUiElements() {
+        super.updateUiElements();
         ((ProgressBar) findViewById(R.id.progress_splash)).getIndeterminateDrawable().setColorFilter(getPrimaryColor(), PorterDuff.Mode.SRC_ATOP);
         findViewById(org.horaapps.leafpic.R.id.Splah_Bg).setBackgroundColor(getBackgroundColor());
     }

--- a/app/src/main/java/org/horaapps/leafpic/activities/base/ThemedActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/base/ThemedActivity.java
@@ -7,9 +7,11 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SwitchCompat;
+import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -27,6 +29,8 @@ import org.horaapps.leafpic.util.ColorPalette;
 import org.horaapps.leafpic.util.PreferenceUtil;
 import org.horaapps.leafpic.util.Theme;
 import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+import org.horaapps.leafpic.util.ViewUtil;
 
 import java.util.ArrayList;
 
@@ -64,6 +68,14 @@ public abstract class ThemedActivity extends AppCompatActivity implements UiElem
         coloredNavBar = SP.getBoolean(getString(R.string.preference_colored_nav_bar), false);
         obscuredStatusBar = SP.getBoolean(getString(R.string.preference_translucent_status_bar),true);
         applyThemeSingleImgAct = SP.getBoolean(getString(R.string.preference_apply_theme_pager), true);
+    }
+
+    @CallSuper
+    @Override
+    public void updateUiElements() {
+        for (View view : ViewUtil.getAllChildren(findViewById(android.R.id.content))) {
+            if (view instanceof Themeable) ((Themeable) view).refreshTheme(getThemeHelper());
+        }
     }
 
     @Override

--- a/app/src/main/java/org/horaapps/leafpic/settings/ColorsSetting.java
+++ b/app/src/main/java/org/horaapps/leafpic/settings/ColorsSetting.java
@@ -68,7 +68,9 @@ public class ColorsSetting extends ThemedSetting {
 
     public interface ColorChooser {
         void onColorSelected(int color);
+
         void onDialogDismiss();
+
         void onColorChanged(int color);
     }
 
@@ -123,7 +125,10 @@ public class ColorsSetting extends ThemedSetting {
 
         dialogBuilder.setPositiveButton(getActivity().getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
+                AlertDialog alertDialog = (AlertDialog) dialog;
+                alertDialog.setOnDismissListener(null);
                 chooser.onColorSelected(colorPicker2.getColor());
+
             }
         });
 

--- a/app/src/main/java/org/horaapps/leafpic/util/Themeable.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/Themeable.java
@@ -1,0 +1,9 @@
+package org.horaapps.leafpic.util;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ * Views that can react to theme changes should implement this.
+ */
+public interface Themeable {
+    void refreshTheme(ThemeHelper themeHelper);
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/ViewUtil.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/ViewUtil.java
@@ -1,0 +1,46 @@
+package org.horaapps.leafpic.util;
+
+import android.app.Activity;
+import android.content.res.Resources;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ViewUtil {
+    // http://stackoverflow.com/questions/18668897/android-get-all-children-elements-of-a-viewgroup
+    public static List<View> getAllChildren(View target) {
+        if (!(target instanceof ViewGroup)) return Collections.singletonList(target);
+
+        ArrayList<View> allChildren = new ArrayList<>();
+        ViewGroup viewGroup = (ViewGroup) target;
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            View child = viewGroup.getChildAt(i);
+            ArrayList<View> targetsChildren = new ArrayList<>();
+            targetsChildren.add(target);
+            targetsChildren.addAll(getAllChildren(child));
+            allChildren.addAll(targetsChildren);
+        }
+        return allChildren;
+    }
+
+    public static boolean hasNavBar(Activity activity) {
+        Resources resources = activity.getResources();
+        int id = resources.getIdentifier("config_showNavigationBar", "bool", "android");
+        if (id > 0) {
+            return resources.getBoolean(id);
+        } else {    // Check for keys
+            boolean hasMenuKey = ViewConfiguration.get(activity).hasPermanentMenuKey();
+            boolean hasBackKey = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK);
+            return !hasMenuKey && !hasBackKey;
+        }
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/SettingBasic.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/SettingBasic.java
@@ -1,0 +1,83 @@
+package org.horaapps.leafpic.views;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Build;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.mikepenz.iconics.view.IconicsImageView;
+
+import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class SettingBasic extends FrameLayout implements Themeable {
+    private final String iconString;
+    @StringRes private final int titleRes;
+    @StringRes private final int captionRes;
+    @BindView(R.id.icon) IconicsImageView icon;
+    @BindView(R.id.title) TextView title;
+    @BindView(R.id.caption) TextView caption;
+
+    public SettingBasic(Context context) {
+        this(context, null);
+    }
+
+    public SettingBasic(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public SettingBasic(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+        setBackgroundResource(R.drawable.ripple);
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        inflater.inflate(R.layout.view_setting_basic, this);
+
+        TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.SettingBasic);
+        iconString = a.getString(R.styleable.SettingBasic_settingIcon);
+        titleRes = a.getResourceId(R.styleable.SettingBasic_settingTitle, 0);
+        captionRes = a.getResourceId(R.styleable.SettingBasic_settingCaption, 0);
+        int minimumApi = a.getInteger(R.styleable.SettingBasic_settingMinApi, 0);
+        a.recycle();
+
+        if (Build.VERSION.SDK_INT < minimumApi) setVisibility(GONE);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        ButterKnife.bind(this);
+
+        icon.setIcon(iconString);
+        title.setText(titleRes);
+        caption.setText(captionRes);
+
+        setPadding(
+                (int) getResources().getDimension(R.dimen.medium_spacing),
+                0,
+                (int) getResources().getDimension(R.dimen.medium_spacing),
+                0
+        );
+        setMinimumHeight((int) getResources().getDimension(R.dimen.listitem_height_twoline));
+
+        super.onFinishInflate();
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+
+    }
+
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/SettingWithSwitchView.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/SettingWithSwitchView.java
@@ -1,0 +1,128 @@
+package org.horaapps.leafpic.views;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.os.Build;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.v7.widget.SwitchCompat;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.mikepenz.iconics.view.IconicsImageView;
+
+import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.activities.base.ThemedActivity;
+import org.horaapps.leafpic.util.PreferenceUtil;
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class SettingWithSwitchView extends FrameLayout implements View.OnClickListener, Themeable {
+    private final String iconString;
+    private final String preferenceKey;
+    @StringRes private final int titleRes;
+    @StringRes private final int captionRes;
+    private final boolean defaultValue;
+    @BindView(R.id.icon) IconicsImageView icon;
+    @BindView(R.id.title) TextView title;
+    @BindView(R.id.caption) TextView caption;
+    @BindView(R.id.toggle) SwitchCompat toggle;
+    private PreferenceUtil preferences;
+    @Nullable private OnClickListener clickListener;
+
+    public SettingWithSwitchView(Context context) {
+        this(context, null);
+    }
+
+    public SettingWithSwitchView(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public SettingWithSwitchView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+        setBackgroundResource(R.drawable.ripple);
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        inflater.inflate(R.layout.view_setting_switch, this);
+
+        TypedArray a = getContext().obtainStyledAttributes(attrs, R.styleable.SettingWithSwitchView);
+        iconString = a.getString(R.styleable.SettingBasic_settingIcon);
+        final int prefKeyRes = a.getResourceId(R.styleable.SettingWithSwitchView_settingPreferenceKey, 0);
+        if (prefKeyRes == 0) throw new IllegalArgumentException("Invalid preference reference");
+        preferenceKey = getResources().getString(prefKeyRes);
+        titleRes = a.getResourceId(R.styleable.SettingBasic_settingTitle, 0);
+        captionRes = a.getResourceId(R.styleable.SettingBasic_settingCaption, 0);
+        defaultValue = a.getBoolean(R.styleable.SettingWithSwitchView_settingDefaultValue, false);
+        int minimumApi = a.getInteger(R.styleable.SettingBasic_settingMinApi, 0);
+        a.recycle();
+
+        preferences = PreferenceUtil.getInstance(getContext());
+        if (Build.VERSION.SDK_INT < minimumApi) setVisibility(GONE);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        ButterKnife.bind(this);
+
+        icon.setIcon(iconString);
+        title.setText(titleRes);
+        caption.setText(captionRes);
+        toggle.setChecked(isChecked());
+        super.setOnClickListener(this);
+
+        setPadding(
+                (int) getResources().getDimension(R.dimen.medium_spacing),
+                0,
+                (int) getResources().getDimension(R.dimen.medium_spacing),
+                0
+        );
+        setMinimumHeight((int) getResources().getDimension(R.dimen.listitem_height_twoline));
+
+        super.onFinishInflate();
+    }
+
+    @Override
+    public void setOnClickListener(@Nullable OnClickListener clickListener) {
+        this.clickListener = clickListener;
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (!isInEditMode()) refreshTheme(((ThemedActivity) getContext()).getThemeHelper());
+    }
+
+    @Override
+    public void onClick(View view) {
+        toggle();
+        refreshTheme(((ThemedActivity) getContext()).getThemeHelper());
+        if (clickListener != null) clickListener.onClick(this);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        themeHelper.setSwitchCompactColor(toggle, themeHelper.getAccentColor());
+    }
+
+    public boolean isChecked() {
+        return preferences.getBoolean(preferenceKey, defaultValue);
+    }
+
+    public boolean toggle() {
+        preferences.getEditor().putBoolean(preferenceKey, !isChecked()).apply();
+        boolean checked = isChecked();
+        toggle.setChecked(checked);
+        return checked;
+    }
+
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableCardView.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableCardView.java
@@ -1,0 +1,31 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.CardView;
+import android.util.AttributeSet;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableCardView extends CardView implements Themeable {
+    public ThemeableCardView(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableCardView(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableCardView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        setCardBackgroundColor(themeHelper.getCardBackgroundColor());
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableScrollView.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableScrollView.java
@@ -1,0 +1,31 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+import android.widget.ScrollView;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableScrollView extends ScrollView implements Themeable {
+    public ThemeableScrollView(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableScrollView(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableScrollView(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        themeHelper.setScrollViewColor(this);
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsCaption.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsCaption.java
@@ -1,0 +1,30 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableSettingsCaption extends android.support.v7.widget.AppCompatTextView implements Themeable {
+    public ThemeableSettingsCaption(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableSettingsCaption(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableSettingsCaption(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        setTextColor(themeHelper.getSubTextColor());
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsCategory.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsCategory.java
@@ -1,0 +1,30 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableSettingsCategory extends android.support.v7.widget.AppCompatTextView implements Themeable {
+    public ThemeableSettingsCategory(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableSettingsCategory(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableSettingsCategory(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        themeHelper.setTextViewColor(this, themeHelper.getAccentColor());
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsIcon.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsIcon.java
@@ -1,0 +1,32 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+
+import com.mikepenz.iconics.view.IconicsImageView;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableSettingsIcon extends IconicsImageView implements Themeable {
+    public ThemeableSettingsIcon(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableSettingsIcon(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableSettingsIcon(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        setColor(themeHelper.getIconColor());
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsTitle.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableSettingsTitle.java
@@ -1,0 +1,30 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.util.AttributeSet;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableSettingsTitle extends android.support.v7.widget.AppCompatTextView implements Themeable {
+    public ThemeableSettingsTitle(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableSettingsTitle(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableSettingsTitle(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        setTextColor(themeHelper.getTextColor());
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableToolbar.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/themeable/ThemeableToolbar.java
@@ -1,0 +1,31 @@
+package org.horaapps.leafpic.views.themeable;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.Toolbar;
+import android.util.AttributeSet;
+
+import org.horaapps.leafpic.util.ThemeHelper;
+import org.horaapps.leafpic.util.Themeable;
+
+/**
+ * Created by darken (darken@darken.eu) on 04.03.2017.
+ */
+public class ThemeableToolbar extends Toolbar implements Themeable {
+    public ThemeableToolbar(Context context) {
+        this(context, null);
+    }
+
+    public ThemeableToolbar(Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ThemeableToolbar(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        setBackgroundColor(themeHelper.getPrimaryColor());
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,45 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
+    android:id="@+id/setting_background"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/setting_background"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
-
-    <!--TOOLBAR-->
 
     <include
         android:id="@+id/toolbar"
         layout="@layout/toolbar"
         android:background="@color/md_dark_appbar"
-        android:windowActionBarOverlay="true" />
+        android:windowActionBarOverlay="true"/>
+
     <ScrollView
         android:id="@+id/settingAct_scrollView"
-        android:scrollbarSize="4dip"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:scrollbarSize="4dip">
+
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical">
 
             <!--GENERAL-->
-
-            <android.support.v7.widget.CardView
+            <org.horaapps.leafpic.views.themeable.ThemeableCardView
                 android:id="@+id/general_setting_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/card_spacing"
-                app:cardCornerRadius="@dimen/card_corner_radius"
-                app:cardElevation="@dimen/card_elevation"
+                android:clickable="true"
                 android:foreground="@drawable/ripple"
-                android:clickable="true">
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation">
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
-                    <TextView
+
+                    <org.horaapps.leafpic.views.themeable.ThemeableSettingsCategory
                         android:id="@+id/general_setting_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -51,208 +52,61 @@
                         android:textStyle="bold"/>
 
                     <!-- SECURITY -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_security"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/security_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="faw-user-secret"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/security_item_title"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/security"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/security_item_sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/security_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/security_sub"
+                        app:settingIcon="faw-user-secret"
+                        app:settingTitle="@string/security"/>
 
                     <!-- NUMBER OF COLUMNS -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_n_columns"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/n_columns_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-view-column"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/n_columns_Item_Title"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/multi_column"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/n_columns_Item_Title_Sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/multi_column_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/multi_column_sub"
+                        app:settingIcon="gmd-view-column"
+                        app:settingTitle="@string/multi_column"/>
 
                     <!-- EXCLUDED ALBUM-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_white_list"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/white_list_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-burst-mode"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/white_list_item_title"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/manage_your_folders"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/white_list_item_title_sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/manage_your_folders_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/manage_your_folders_sub"
+                        app:settingIcon="gmd-burst-mode"
+                        app:settingTitle="@string/manage_your_folders"/>
 
                     <!-- FAB OPTIONS -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_fab_options"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_fab"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/fab_options_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-add-circle"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="44dp">
-                                <TextView
-                                    android:id="@+id/fab_options_item_title"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/fab_options"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="16sp" />
-                                <TextView
-                                    android:id="@+id/fab_options_item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/fab_options_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="14sp" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/sw_show_fab"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/fab_options_sub"
+                        app:settingIcon="gmd-add-circle"
+                        app:settingPreferenceKey="@string/preference_show_fab"
+                        app:settingTitle="@string/fab_options"/>
                 </LinearLayout>
-            </android.support.v7.widget.CardView>
+            </org.horaapps.leafpic.views.themeable.ThemeableCardView>
 
             <!--THEME-->
-
-            <android.support.v7.widget.CardView
+            <org.horaapps.leafpic.views.themeable.ThemeableCardView
                 android:id="@+id/theme_setting_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/card_spacing"
-                app:cardCornerRadius="@dimen/card_corner_radius"
-                app:cardElevation="@dimen/card_elevation"
+                android:clickable="true"
                 android:foreground="@drawable/ripple"
-                android:clickable="true">
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation">
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
-                    <TextView
+
+                    <org.horaapps.leafpic.views.themeable.ThemeableSettingsCategory
                         android:id="@+id/theme_setting_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -264,355 +118,95 @@
                         android:textStyle="bold"/>
 
                     <!--BASIC THEME-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_basic_theme"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/basic_theme_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-invert-colors"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/basic_theme_item"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/base_theme"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text"/>
-                            <TextView
-                                android:id="@+id/basic_theme_item_sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/base_theme_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/base_theme_sub"
+                        app:settingIcon="gmd-invert-colors"
+                        app:settingTitle="@string/base_theme"/>
 
                     <!--PRIMARY COLOR-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_primaryColor"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/primary_color_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-color-lens"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/PrimaryColor_Item"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/primary_color"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/PrimaryColor_Item_Sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/primary_color_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/primary_color_sub"
+                        app:settingIcon="gmd-color-lens"
+                        app:settingTitle="@string/primary_color"/>
 
                     <!--ACCENT COLOR-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_accentColor"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/accent_color_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-format-color-fill"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/accentColor_Item"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/accent_color"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/accentColor_Item_Sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/accent_color_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/accent_color_sub"
+                        app:settingIcon="gmd-format-color-fill"
+                        app:settingTitle="@string/accent_color"/>
 
                     <!-- APPLY THEME ON 3TH ACT -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_custom_thirdAct"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/custom_3thact_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-colorize"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/custom_3thAct_title"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/media_viewer"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/custom_3thAct_Sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/custom_3thAct_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/custom_3thAct_sub"
+                        app:settingIcon="gmd-colorize"
+                        app:settingTitle="@string/media_viewer"/>
+
 
                     <!-- CARD VIEW STYLE -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_card_view_style"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/card_view_style_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-dashboard"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/card_view_style_title"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/album_card_view"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/card_view_style_Sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/album_card_view_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/album_card_view_sub"
+                        app:settingIcon="gmd-dashboard"
+                        app:settingTitle="@string/album_card_view"/>
+
 
                     <!-- TRANSLUCENT STATUS BAR-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_TraslucentStatusBar"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_statusbar"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:visibility="gone"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/traslucent_statusbar_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-web-asset"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing"
-                        />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="45dp">
-                                <TextView
-                                    android:id="@+id/Traslucent_StatusBar_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/traslucent_statusbar"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/Traslucent_StatusBar_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/traslucent_statusbar_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/SetTraslucentStatusBar"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/traslucent_statusbar_sub"
+                        app:settingDefaultValue="true"
+                        app:settingIcon="gmd-web-asset"
+                        app:settingMinApi="21"
+                        app:settingPreferenceKey="@string/preference_translucent_status_bar"
+                        app:settingTitle="@string/traslucent_statusbar"/>
 
                     <!--COLORED NAV BAR-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_ColoredNavBar"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_colored_navbar"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:visibility="gone"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/nav_bar_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-video-label"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing"
-                        />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="45dp">
-                                <TextView
-                                    android:id="@+id/NavBar_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/colored_navbar"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/NavBar_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/colored_navbar_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/SetColoredNavBar"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/colored_navbar_sub"
+                        app:settingDefaultValue="false"
+                        app:settingIcon="gmd-video-label"
+                        app:settingMinApi="21"
+                        app:settingPreferenceKey="@string/preference_colored_nav_bar"
+                        app:settingTitle="@string/colored_navbar"/>
                 </LinearLayout>
-            </android.support.v7.widget.CardView>
+            </org.horaapps.leafpic.views.themeable.ThemeableCardView>
 
             <!--MEDIA VIEWER SETTING-->
-
-            <android.support.v7.widget.CardView
+            <org.horaapps.leafpic.views.themeable.ThemeableCardView
                 android:id="@+id/preview_picture_setting_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/card_spacing"
-                app:cardCornerRadius="@dimen/card_corner_radius"
-                app:cardElevation="@dimen/card_elevation"
+                android:clickable="true"
                 android:foreground="@drawable/ripple"
-                android:clickable="true">
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation">
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
-                    <TextView
+
+                    <org.horaapps.leafpic.views.themeable.ThemeableSettingsCategory
                         android:id="@+id/picture_setting_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -621,263 +215,70 @@
                         android:text="@string/media_viewer"
                         android:textColor="@color/md_dark_background"
                         android:textSize="@dimen/medium_text"
-                        android:textStyle="bold" />
+                        android:textStyle="bold"/>
 
                     <!--MAX BRIGHTNESS-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_max_luminosity"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_max_brightness"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/ll_switch_max_luminosity_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-settings-brightness"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="45dp">
-                                <TextView
-                                    android:id="@+id/max_luminosity_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/max_brightness"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/max_luminosity_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/max_brightness_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/set_max_luminosity"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/max_brightness_sub"
+                        app:settingIcon="gmd-settings-brightness"
+                        app:settingPreferenceKey="@string/preference_max_brightness"
+                        app:settingTitle="@string/max_brightness"/>
 
                     <!-- PICTURE ORIENTATION-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_picture_orientation"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_picture_orientation"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/ll_switch_picture_orientation_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-screen-rotation"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/medium_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="45dp">
-                                <TextView
-                                    android:id="@+id/picture_orientation_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/picture_orientation"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/picture_orientation_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/picture_orientation_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/set_picture_orientation"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/picture_orientation_sub"
+                        app:settingIcon="gmd-screen-rotation"
+                        app:settingPreferenceKey="@string/preference_auto_rotate"
+                        app:settingTitle="@string/picture_orientation"/>
 
                     <!-- FULL resolution TODO: do something -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_full_resolution"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_full_resolution"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true"
-                        android:visibility="gone">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/ll_switch_full_resolution_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-image"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/medium_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="45dp">
-                                <TextView
-                                    android:id="@+id/full_resolution_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/delay_load_full_size_image"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/full_resolution_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/load_full_image_when_zoom_in"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/set_full_resolution"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        android:visibility="gone"
+                        app:settingCaption="@string/load_full_image_when_zoom_in"
+                        app:settingIcon="gmd-image"
+                        app:settingPreferenceKey="@string/preference_delay_full_image"
+                        app:settingTitle="@string/delay_load_full_size_image"/>
+
 
                     <!--SWIPE ORIENTATION TODO: implement feature -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_media_viewer_swipe_direction"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_swipe_direction"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:gravity="center_vertical"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true"
-                        android:visibility="gone">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/media_viewer_swipe_direction_Icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-compare-arrows"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="44dp">
-                                <TextView
-                                    android:id="@+id/media_viewer_swipe_direction_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/media_viewer_swipe_direction"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/media_viewer_swipe_direction_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/media_viewer_swipe_direction_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/Set_media_viewer_swipe_direction"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        android:visibility="gone"
+                        app:settingCaption="@string/media_viewer_swipe_direction_sub"
+                        app:settingIcon="gmd-compare-arrows"
+                        app:settingPreferenceKey="@string/preference_swipe_direction_inverted"
+                        app:settingTitle="@string/media_viewer_swipe_direction"/>
                 </LinearLayout>
-            </android.support.v7.widget.CardView>
+            </org.horaapps.leafpic.views.themeable.ThemeableCardView>
 
             <!--VIDEO PLAYER SETTINGS-->
-
-            <android.support.v7.widget.CardView
+            <org.horaapps.leafpic.views.themeable.ThemeableCardView
                 android:id="@+id/video_setting_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/card_spacing"
-                app:cardCornerRadius="@dimen/card_corner_radius"
-                app:cardElevation="@dimen/card_elevation"
+                android:clickable="true"
                 android:foreground="@drawable/ripple"
-                android:clickable="true">
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation">
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
-                    <TextView
+
+                    <org.horaapps.leafpic.views.themeable.ThemeableSettingsCategory
                         android:id="@+id/video_setting_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -886,85 +287,39 @@
                         android:text="@string/video"
                         android:textColor="@color/md_dark_background"
                         android:textSize="@dimen/medium_text"
-                        android:textStyle="bold" />
+                        android:textStyle="bold"/>
 
                     <!-- INCLUDE VIDEO -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_switch_include_video"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_include_video"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/internal_include_video"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-videocam"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="45dp">
-                                <TextView
-                                    android:id="@+id/include_video_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/include_video"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/include_video_Item_Sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="Display also video"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/set_include_video"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/include_video_sub"
+                        app:settingIcon="gmd-videocam"
+                        app:settingPreferenceKey="@string/preference_swipe_direction_inverted"
+                        app:settingTitle="@string/include_video"/>
 
                 </LinearLayout>
-            </android.support.v7.widget.CardView>
+            </org.horaapps.leafpic.views.themeable.ThemeableCardView>
 
             <!--ADVANCED SETTING-->
 
-            <android.support.v7.widget.CardView
+            <org.horaapps.leafpic.views.themeable.ThemeableCardView
                 android:id="@+id/advanced_setting_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/card_spacing"
-                app:cardCornerRadius="@dimen/card_corner_radius"
-                app:cardElevation="@dimen/card_elevation"
+                android:clickable="true"
                 android:foreground="@drawable/ripple"
-                android:clickable="true">
+                app:cardCornerRadius="@dimen/card_corner_radius"
+                app:cardElevation="@dimen/card_elevation">
+
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
-                    <TextView
+
+                    <org.horaapps.leafpic.views.themeable.ThemeableSettingsCategory
                         android:id="@+id/advanced_setting_title"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -973,168 +328,38 @@
                         android:text="@string/advanced"
                         android:textColor="@color/md_dark_background"
                         android:textSize="@dimen/medium_text"
-                        android:textStyle="bold" />
+                        android:textStyle="bold"/>
 
 
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_sub_scaling"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_sub_scaling"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/sub_scaling_Icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-photo-library"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_text"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="44dp">
-                                <TextView
-                                    android:id="@+id/sub_scaling_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/sub_scaling_image_view"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/sub_scaling_Item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/sub_scaling_image_view_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/sw_sub_scaling"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/sub_scaling_image_view_sub"
+                        app:settingIcon="gmd-photo-library"
+                        app:settingPreferenceKey="@string/preference_sub_scaling"
+                        app:settingTitle="@string/sub_scaling_image_view"/>
 
                     <!-- MAPS PROVIDER-->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
+                    <org.horaapps.leafpic.views.SettingBasic
                         android:id="@+id/ll_map_provider"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/map_provider_icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="faw-map-signs"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:orientation="vertical"
-                            android:paddingTop="@dimen/small_spacing"
-                            android:paddingRight="@dimen/medium_text"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <TextView
-                                android:id="@+id/map_provider_item_title"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/map_provider"
-                                android:textColor="@color/md_dark_background"
-                                android:textSize="@dimen/medium_text" />
-                            <TextView
-                                android:id="@+id/map_provider_item_sub"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/map_provider_sub"
-                                android:textColor="@color/md_grey_400"
-                                android:textSize="@dimen/sub_medium_text" />
-                        </LinearLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/map_provider_sub"
+                        app:settingIcon="faw-map-signs"
+                        app:settingTitle="@string/map_provider"/>
 
                     <!-- AUTO UPDATE MEDIA -->
-
-                    <LinearLayout
-                        xmlns:android="http://schemas.android.com/apk/res/android"
-                        android:id="@+id/ll_auto_update_media"
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_auto_update_media"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:background="@drawable/ripple"
-                        android:clickable="true">
-                        <com.mikepenz.iconics.view.IconicsImageView
-                            android:id="@+id/auto_update_media_Icon"
-                            android:layout_width="@dimen/icon_width_height"
-                            android:layout_height="@dimen/icon_width_height"
-                            android:layout_gravity="center_vertical"
-                            app:iiv_icon="gmd-update"
-                            android:layout_marginLeft="@dimen/big_spacing"
-                            android:layout_marginRight="@dimen/big_spacing" />
-                        <RelativeLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            android:paddingTop="@dimen/medium_spacing"
-                            android:paddingRight="@dimen/medium_spacing"
-                            android:paddingBottom="@dimen/small_spacing">
-                            <LinearLayout
-                                android:layout_width="match_parent"
-                                android:layout_height="wrap_content"
-                                android:layout_centerVertical="true"
-                                android:orientation="vertical"
-                                android:layout_marginEnd="44dp">
-                                <TextView
-                                    android:id="@+id/auto_update_media_Item"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/auto_update_media"
-                                    android:textColor="@color/md_dark_background"
-                                    android:textSize="@dimen/medium_text" />
-                                <TextView
-                                    android:id="@+id/auto_update_media_Item_sub"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:text="@string/auto_update_media_sub"
-                                    android:textColor="@color/md_grey_400"
-                                    android:textSize="@dimen/sub_medium_text" />
-                            </LinearLayout>
-                            <android.support.v7.widget.SwitchCompat
-                                android:id="@+id/SetAutoUpdateMedia"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_gravity="center_vertical"
-                                android:button="@null"
-                                android:hapticFeedbackEnabled="true"
-                                android:layout_centerVertical="true"
-                                android:layout_alignParentEnd="true" />
-                        </RelativeLayout>
-                    </LinearLayout>
+                        app:settingCaption="@string/auto_update_media_sub"
+                        app:settingIcon="gmd-update"
+                        app:settingPreferenceKey="@string/preference_auto_update_media"
+                        app:settingTitle="@string/auto_update_media"/>
                 </LinearLayout>
-            </android.support.v7.widget.CardView>
+            </org.horaapps.leafpic.views.themeable.ThemeableCardView>
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/toolbar.xml
+++ b/app/src/main/res/layout/toolbar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.Toolbar
+<org.horaapps.leafpic.views.themeable.ThemeableToolbar
     xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/MyToolbar"
     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/view_setting_basic.xml
+++ b/app/src/main/res/layout/view_setting_basic.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="wrap_content"
+       tools:parentTag="FrameLayout">
+
+    <org.horaapps.leafpic.views.themeable.ThemeableSettingsIcon
+        android:id="@+id/icon"
+        android:layout_width="@dimen/icon_width_height"
+        android:layout_height="@dimen/icon_width_height"
+        android:layout_gravity="start|center_vertical"
+        app:iiv_icon="gmd-add-circle"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="56dp"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/small_spacing"
+        android:paddingTop="@dimen/small_spacing">
+
+        <org.horaapps.leafpic.views.themeable.ThemeableSettingsTitle
+            android:id="@+id/title"
+            style="@style/TextAppearance.AppCompat.Subhead"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/md_dark_background"
+            tools:text="@string/fab_options"/>
+
+        <org.horaapps.leafpic.views.themeable.ThemeableSettingsCaption
+            android:id="@+id/caption"
+            style="@style/TextAppearance.AppCompat.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/md_grey_400"
+            tools:text="@string/fab_options_sub"/>
+    </LinearLayout>
+</merge>

--- a/app/src/main/res/layout/view_setting_switch.xml
+++ b/app/src/main/res/layout/view_setting_switch.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+       android:layout_height="wrap_content"
+       tools:paddingLeft="16dp"
+       tools:paddingRight="16dp"
+       tools:parentTag="FrameLayout">
+
+    <org.horaapps.leafpic.views.themeable.ThemeableSettingsIcon
+        android:id="@+id/icon"
+        android:layout_width="@dimen/icon_width_height"
+        android:layout_height="@dimen/icon_width_height"
+        android:layout_gravity="start|center_vertical"
+        app:iiv_icon="gmd-add-circle"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:layout_marginEnd="48dp"
+        android:layout_marginStart="56dp"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/small_spacing"
+        android:paddingTop="@dimen/small_spacing">
+
+        <org.horaapps.leafpic.views.themeable.ThemeableSettingsTitle
+            android:id="@+id/title"
+            style="@style/Base.TextAppearance.AppCompat.Subhead"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/md_dark_background"
+            tools:text="@string/fab_options"/>
+
+        <org.horaapps.leafpic.views.themeable.ThemeableSettingsCaption
+            android:id="@+id/caption"
+            style="@style/TextAppearance.AppCompat.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="@color/md_grey_400"
+            tools:text="@string/fab_options_sub"/>
+    </LinearLayout>
+
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/toggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|center_vertical"
+        android:hapticFeedbackEnabled="true"/>
+
+</merge>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -5,4 +5,19 @@
         <attr name="rewind_increment"/>
         <attr name="fastforward_increment"/>
     </declare-styleable>
+    <declare-styleable name="SettingBasic">
+        <attr name="settingIcon" format="string"/>
+        <attr name="settingTitle" format="reference"/>
+        <attr name="settingCaption" format="reference"/>
+        <attr name="settingMinApi" format="integer"/>
+    </declare-styleable>
+    <declare-styleable name="SettingWithSwitchView">
+        <attr name="settingIcon"/>
+        <attr name="settingTitle"/>
+        <attr name="settingCaption"/>
+        <attr name="settingMinApi"/>
+        <attr name="settingDefaultValue" format="boolean"/>
+        <attr name="settingPreferenceKey" format="reference"/>
+    </declare-styleable>
+
 </resources>

--- a/app/src/main/res/values/dimesions.xml
+++ b/app/src/main/res/values/dimesions.xml
@@ -47,4 +47,6 @@
     <dimen name="progress_circle_width_height">48dp</dimen>
     <dimen name="snackbar_elevation">10dp</dimen>
 
+    <!-- List items -->
+    <dimen name="listitem_height_twoline">72dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -301,6 +301,7 @@ and this could make the media inaccessible from other apps. Use the exclude opti
     <string name="unable_to_fix_date">Unable to fix date</string>
     <string name="compression_settings">Compression settings</string>
     <string name="include_video">Include Video</string>
+    <string name="include_video_sub">Also display videos.</string>
     <string name="fab_options">Show FAB</string>
     <string name="fab_options_sub">Display the floating button.</string>
     <string name="map_provider">Map Provider</string>

--- a/app/src/noGPlay/java/org/horaapps/leafpic/activities/DonateActivity.java
+++ b/app/src/noGPlay/java/org/horaapps/leafpic/activities/DonateActivity.java
@@ -3,6 +3,7 @@ package org.horaapps.leafpic.activities;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.os.Bundle;
+import android.support.annotation.CallSuper;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
@@ -71,9 +72,10 @@ public class DonateActivity extends ThemedActivity {
         });
     }
 
+    @CallSuper
     @Override
     public void updateUiElements() {
-
+        super.updateUiElements();
         toolbar.setBackgroundColor(getPrimaryColor());
         setStatusBarColor();
         setNavBarColor();

--- a/app/src/withGPlay/java/org/horaapps/leafpic/activities/DonateActivity.java
+++ b/app/src/withGPlay/java/org/horaapps/leafpic/activities/DonateActivity.java
@@ -161,7 +161,7 @@ public class DonateActivity extends ThemedActivity {
 
     @Override
     public void updateUiElements() {
-
+        super.updateUiElements();
         toolbar.setBackgroundColor(getPrimaryColor());
         setStatusBarColor();
         setNavBarColor();

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
No functional changes, just refactoring.

* Introduced `Themeable` interface  that views can implement if they want to be aware of theming.
* Created custom views for settings (that are theming themselves).
* Refactored SettingsActivity to use the new stuff.
* Tweaked settings layouts according to material.io guidelines (some paddings and height issues).
* Updated tooling & support libs

The `Themeable` interface pattern could be introduced to other `Activity`'s and `Fragment`s (in other PR, maybe by someone else?). Moving the theming boilerplate code out of the way would make it more pleasant to work on functional changes.