### PR TITLE
Fixed crash while opening file from intent

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
@@ -215,7 +215,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
             findViewById(R.id.ll_emoji_easter_egg).setVisibility(Hawk.get("emoji_easter_egg", 0) == 1 ? View.VISIBLE : View.GONE);
         }
 
-        media = new ArrayList<>(Collections.singletonList(new Media(getApplicationContext(), uri)));
+        media = new ArrayList<>(Collections.singletonList(new Media(uri)));
         position = 0;
         customUri = true;
     }

--- a/app/src/main/java/org/horaapps/leafpic/data/Media.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/Media.java
@@ -53,10 +53,10 @@ public class Media implements CursorHandler, Parcelable {
         this(path, -1);
     }
 
-    public Media(Context context, Uri mediaUri) {
+    public Media(Uri mediaUri) {
         this.uriString = mediaUri.toString();
         this.path = null;
-        this.mimeType = context.getContentResolver().getType(getUri());
+        this.mimeType = StringUtils.getMimeType(uriString);
     }
 
     public Media(@NotNull Cursor cur) {


### PR DESCRIPTION
Mime type was being set to null because ContentResolver returns null if scheme is not `content://`