### PR TITLE
Added SharedPreferences support, migrated keys from Hawk > SharedPrefs

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/App.java
+++ b/app/src/main/java/org/horaapps/leafpic/App.java
@@ -7,28 +7,28 @@ import com.squareup.leakcanary.LeakCanary;
 
 import org.horaapps.leafpic.data.Album;
 import org.horaapps.leafpic.data.HandlingAlbums;
+import org.horaapps.leafpic.util.preferences.Prefs;
 
 /**
  * Created by dnld on 28/04/16.
  */
-public class App extends /*org.horaapps.liz.App*/ Application {
+public class App extends Application {
 
     private static App mInstance;
 
     @Override
     public void onCreate() {
         super.onCreate();
+        mInstance = this;
+
         if (LeakCanary.isInAnalyzerProcess(this)) {
             // This process is dedicated to LeakCanary for heap analysis.
             // You should not init your app in this process.
             return;
         }
         LeakCanary.install(this);
-        // Normal app init code...
 
-        Hawk.init(this).build();
-
-        mInstance = this;
+        initialiseStorage();
     }
 
     public static App getInstance() {
@@ -43,5 +43,10 @@ public class App extends /*org.horaapps.liz.App*/ Application {
     @Deprecated
     public HandlingAlbums getAlbums() {
         return HandlingAlbums.getInstance(getApplicationContext());
+    }
+
+    private void initialiseStorage() {
+        Prefs.init(this);
+        Hawk.init(this).build();
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/activities/AboutActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/AboutActivity.java
@@ -24,6 +24,7 @@ import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.CustomTabService;
 import org.horaapps.leafpic.util.StringUtils;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ThemedActivity;
 import org.horaapps.liz.ui.ThemedIcon;
 
@@ -152,12 +153,11 @@ public class AboutActivity extends ThemedActivity {
     private void emojiEasterEgg(){
         emojiEasterEggCount++;
         if(emojiEasterEggCount > 3) {
+            boolean showEasterEgg = Prefs.showEasterEgg();
             Toast.makeText(this,
-                    (Hawk.get("emoji_easter_egg", 0) == 0
-                    ? this.getString(R.string.easter_egg_enable)
-                    : this.getString(R.string.easter_egg_disable))
+                    (!showEasterEgg ? this.getString(R.string.easter_egg_enable) : this.getString(R.string.easter_egg_disable))
                     + " " + this.getString(R.string.emoji_easter_egg), Toast.LENGTH_SHORT).show();
-            Hawk.put("emoji_easter_egg", Hawk.get("emoji_easter_egg", 0) == 0 ? 1 : 0);
+            Prefs.setShowEasterEgg(!showEasterEgg);
             emojiEasterEggCount = 0;
         } else Toast.makeText(getBaseContext(), String.valueOf(emojiEasterEggCount), Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/org/horaapps/leafpic/activities/BlackWhiteListActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/BlackWhiteListActivity.java
@@ -28,6 +28,7 @@ import org.horaapps.leafpic.data.HandlingAlbums;
 import org.horaapps.leafpic.data.filter.ImageFileFilter;
 import org.horaapps.leafpic.data.provider.ContentProviderHelper;
 import org.horaapps.leafpic.util.StringUtils;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ui.ThemedIcon;
 
 import java.io.File;
@@ -118,10 +119,26 @@ public class BlackWhiteListActivity extends SharedMediaActivity {
     }
 
     private void checkNothing() {
-        findViewById(R.id.white_list_decription_card).setVisibility((isExcludedMode() || !(Hawk.get("preference_show_tips", true))) ? View.GONE : View.VISIBLE);
-        //TODO: EMOJI EASTER EGG - NOTHING TO SHOW
-        findViewById(R.id.nothing_to_show_placeholder).setVisibility(folders.size() < 1 && isExcludedMode() && Hawk.get("emoji_easter_egg", 0) == 0 ? View.VISIBLE : View.GONE);
-        findViewById(R.id.ll_emoji_easter_egg).setVisibility(folders.size() < 1 && isExcludedMode() && Hawk.get("emoji_easter_egg", 0) == 1 ? View.VISIBLE : View.GONE);
+        findViewById(R.id.white_list_decription_card).setVisibility(
+                showDescriptionCard() ? View.VISIBLE : View.GONE);
+
+        findViewById(R.id.nothing_to_show_placeholder).setVisibility(
+                showNothingToShowPlaceholder() ? View.VISIBLE : View.GONE);
+
+        findViewById(R.id.ll_emoji_easter_egg).setVisibility(
+                showEasterEgg() ? View.VISIBLE : View.GONE);
+    }
+
+    private boolean showDescriptionCard() {
+        return !isExcludedMode() && Prefs.getToggleValue(getString(R.string.preference_show_tips), true);
+    }
+
+    private boolean showNothingToShowPlaceholder() {
+        return folders.size() < 1 && isExcludedMode() && !Prefs.showEasterEgg();
+    }
+
+    private boolean showEasterEgg() {
+        return folders.size() < 1 && isExcludedMode() && Prefs.showEasterEgg();
     }
 
     @Override

--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -42,6 +42,7 @@ import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.LegacyCompatFileProvider;
 import org.horaapps.leafpic.util.Security;
 import org.horaapps.leafpic.util.StringUtils;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ui.ThemedIcon;
 
 import java.util.ArrayList;
@@ -236,7 +237,7 @@ public class MainActivity extends SharedMediaActivity {
         super.onPostResume();
 
         new Thread(() -> {
-            if (Hawk.get("last_version_code", 0) < BuildConfig.VERSION_CODE) {
+            if (Prefs.getLastVersionCode() < BuildConfig.VERSION_CODE) {
                 String titleHtml = String.format(Locale.ENGLISH, "<font color='%d'>%s <b>%s</b></font>", getTextColor(), getString(R.string.changelog), BuildConfig.VERSION_NAME),
                         buttonHtml = String.format(Locale.ENGLISH, "<font color='%d'>%s</font>", getAccentColor(), getString(R.string.view).toUpperCase());
                 Snackbar snackbar = Snackbar
@@ -247,7 +248,7 @@ public class MainActivity extends SharedMediaActivity {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
                     snackbarView.setElevation(getResources().getDimension(R.dimen.snackbar_elevation));
                 snackbar.show();
-                Hawk.put("last_version_code", BuildConfig.VERSION_CODE);
+                Prefs.setLastVersionCode(BuildConfig.VERSION_CODE);
             }
         }).start();
     }
@@ -328,7 +329,7 @@ public class MainActivity extends SharedMediaActivity {
         ((TextView) findViewById(R.id.emoji_easter_egg)).setTextColor(getSubTextColor());
         ((TextView) findViewById(R.id.nothing_to_show_text_emoji_easter_egg)).setTextColor(getSubTextColor());
 
-        if (status && Hawk.get("emoji_easter_egg", 0) == 1) {
+        if (status && Prefs.showEasterEgg()) {
             findViewById(R.id.ll_emoji_easter_egg).setVisibility(View.VISIBLE);
             findViewById(R.id.nothing_to_show_placeholder).setVisibility(View.VISIBLE);
         } else {

--- a/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
@@ -60,6 +60,7 @@ import org.horaapps.leafpic.util.Measure;
 import org.horaapps.leafpic.util.Security;
 import org.horaapps.leafpic.util.StringUtils;
 import org.horaapps.leafpic.util.file.DeleteException;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.leafpic.views.HackyViewPager;
 import org.horaapps.liz.ColorPalette;
 
@@ -210,10 +211,10 @@ public class SingleMediaActivity extends SharedMediaActivity {
             InputStream inputStream = getContentResolver().openInputStream(uri);
             if (inputStream != null) inputStream.close();
         } catch (Exception ex) {
-            //TODO: EMOJI EASTER EGG - THERE'S NOTHING TO SHOW
+            boolean showEasterEgg = Prefs.showEasterEgg();
             ((TextView) findViewById(R.id.nothing_to_show_text_emoji_easter_egg)).setText(R.string.error_occured_open_media);
-            findViewById(R.id.nothing_to_show_placeholder).setVisibility(Hawk.get("emoji_easter_egg", 0) == 0 ? View.VISIBLE : View.GONE);
-            findViewById(R.id.ll_emoji_easter_egg).setVisibility(Hawk.get("emoji_easter_egg", 0) == 1 ? View.VISIBLE : View.GONE);
+            findViewById(R.id.nothing_to_show_placeholder).setVisibility(!showEasterEgg ? View.VISIBLE : View.GONE);
+            findViewById(R.id.ll_emoji_easter_egg).setVisibility(showEasterEgg ? View.VISIBLE : View.GONE);
         }
 
         media = new ArrayList<>(Collections.singletonList(new Media(uri)));
@@ -306,7 +307,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
 
         /**** SETTINGS ****/
 
-        if (Hawk.get("set_max_luminosity", false))
+        if (Prefs.getToggleValue(getString(R.string.preference_max_brightness), false))
             updateBrightness(1.0F);
         else try {
             // TODO: 12/4/16 redo
@@ -318,7 +319,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
             e.printStackTrace();
         }
 
-        if (Hawk.get("set_picture_orientation", false))
+        if (Prefs.getToggleValue(getString(R.string.preference_auto_rotate), false))
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
         else setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_USER);
 

--- a/app/src/main/java/org/horaapps/leafpic/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/AlbumsAdapter.java
@@ -25,6 +25,7 @@ import org.horaapps.leafpic.data.sort.AlbumsComparators;
 import org.horaapps.leafpic.data.sort.SortingMode;
 import org.horaapps.leafpic.data.sort.SortingOrder;
 import org.horaapps.leafpic.util.StringUtils;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ColorPalette;
 import org.horaapps.liz.Theme;
 import org.horaapps.liz.ThemeHelper;
@@ -59,13 +60,13 @@ public class AlbumsAdapter extends ThemedAdapter<AlbumsAdapter.ViewHolder> {
     private SortingMode sortingMode;
 
     private Drawable placeholder;
-    private CardViewStyle cvs;
+    private CardViewStyle cardViewStyle;
 
     public AlbumsAdapter(Context context, SortingMode sortingMode, SortingOrder sortingOrder) {
         super(context);
         albums = new ArrayList<>();
         placeholder = getThemeHelper().getPlaceHolder();
-        cvs = CardViewStyle.fromValue(Hawk.get("card_view_style", 0));
+        cardViewStyle = Prefs.getCardStyle();
         this.sortingMode = sortingMode;
         this.sortingOrder = sortingOrder;
     }
@@ -202,14 +203,14 @@ public class AlbumsAdapter extends ThemedAdapter<AlbumsAdapter.ViewHolder> {
     public void refreshTheme(ThemeHelper theme) {
         placeholder = theme.getPlaceHolder();
 
-        cvs = CardViewStyle.fromValue(Hawk.get("card_view_style", 0));
+        cardViewStyle = Prefs.getCardStyle();
         super.refreshTheme(theme);
     }
 
     @Override
     public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View v;
-        switch (cvs) {
+        switch (cardViewStyle) {
             default:
             case MATERIAL: v = LayoutInflater.from(parent.getContext()).inflate(R.layout.card_album_material, parent, false); break;
             case FLAT: v = LayoutInflater.from(parent.getContext()).inflate(R.layout.card_album_flat, parent, false); break;
@@ -236,9 +237,9 @@ public class AlbumsAdapter extends ThemedAdapter<AlbumsAdapter.ViewHolder> {
 
     @Override
     public void onBindViewHolder(final AlbumsAdapter.ViewHolder holder, int position) {
-
+        // TODO Calvin: Major Refactor - No business logic here.
         Album a = albums.get(position);
-        holder.refreshTheme(getThemeHelper(), cvs, a.isSelected());
+        holder.refreshTheme(getThemeHelper(), cardViewStyle, a.isSelected());
 
         Media f = a.getCover();
 
@@ -269,10 +270,11 @@ public class AlbumsAdapter extends ThemedAdapter<AlbumsAdapter.ViewHolder> {
 
         holder.mediaLabel.setTextColor(textColor);
 
+        // TODO Calvin: Check if "show_n_photos" is being set anywhere
         holder.llCount.setVisibility(Hawk.get("show_n_photos", true) ? View.VISIBLE : View.GONE);
         holder.name.setText(StringUtils.htmlFormat(a.getName(), textColor, false, true));
         holder.nMedia.setText(StringUtils.htmlFormat(String.valueOf(a.getCount()), accentColor, true, false));
-        holder.path.setVisibility(Hawk.get("show_album_path", false) ? View.VISIBLE : View.GONE);
+        holder.path.setVisibility(Prefs.showAlbumPath() ? View.VISIBLE : View.GONE);
         holder.path.setText(a.getPath());
 
         //START Animation MAKES BUG ON FAST TAP ON CARD

--- a/app/src/main/java/org/horaapps/leafpic/data/AlbumsHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/AlbumsHelper.java
@@ -7,6 +7,7 @@ import android.graphics.BitmapFactory;
 import android.media.MediaScannerConnection;
 import android.media.ThumbnailUtils;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.widget.Toast;
 
 import com.orhanobut.hawk.Hawk;
@@ -15,6 +16,7 @@ import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.activities.SplashScreen;
 import org.horaapps.leafpic.data.sort.SortingMode;
 import org.horaapps.leafpic.data.sort.SortingOrder;
+import org.horaapps.leafpic.util.preferences.Prefs;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -64,20 +66,22 @@ public class AlbumsHelper {
         }
     }
 
-    public static SortingMode getSortingMode(Context context) {
-        return SortingMode.fromValue(Hawk.get("albums_sorting_mode", SortingMode.DATE.getValue()));
+    @NonNull
+    public static SortingMode getSortingMode() {
+        return Prefs.getAlbumSortingMode();
     }
 
-    public static SortingOrder getSortingOrder(Context context) {
-        return SortingOrder.fromValue(Hawk.get("albums_sorting_order", SortingOrder.DESCENDING.getValue()));
+    @NonNull
+    public static SortingOrder getSortingOrder() {
+        return Prefs.getAlbumSortingOrder();
     }
 
-    public static void setSortingMode(Context context, SortingMode sortingMode) {
-        Hawk.put("albums_sorting_mode", sortingMode.getValue());
+    public static void setSortingMode(@NonNull SortingMode sortingMode) {
+        Prefs.setAlbumSortingMode(sortingMode);
     }
 
-    public static void setSortingOrder(Context context, SortingOrder sortingOrder) {
-        Hawk.put("albums_sorting_order", sortingOrder.getValue());
+    public static void setSortingOrder(@NonNull SortingOrder sortingOrder) {
+        Prefs.setAlbumSortingOrder(sortingOrder);
     }
 
     public static void scanFile(Context context, String[] path) {  MediaScannerConnection.scanFile(context, path, null, null); }

--- a/app/src/main/java/org/horaapps/leafpic/data/provider/CPHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/provider/CPHelper.java
@@ -12,6 +12,7 @@ import org.horaapps.leafpic.data.filter.FoldersFileFilter;
 import org.horaapps.leafpic.data.filter.ImageFileFilter;
 import org.horaapps.leafpic.data.sort.SortingMode;
 import org.horaapps.leafpic.data.sort.SortingOrder;
+import org.horaapps.leafpic.util.preferences.Prefs;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -63,7 +64,7 @@ public class CPHelper {
 
         ArrayList<Object> args = new ArrayList<>();
 
-        if (Hawk.get("set_include_video", true)) {
+        if (Prefs.showVideos()) {
             query.selection(String.format("%s=? or %s=?) group by (%s) %s ",
                     MediaStore.Files.FileColumns.MEDIA_TYPE,
                     MediaStore.Files.FileColumns.MEDIA_TYPE,
@@ -94,7 +95,7 @@ public class CPHelper {
 
     private static Observable<Album> getHiddenAlbums(Context context, ArrayList<String> excludedAlbums) {
 
-        boolean includeVideo = Hawk.get("set_include_video", true);
+        boolean includeVideo = Prefs.showVideos();
         return Observable.create(subscriber -> {
             try {
 
@@ -184,7 +185,7 @@ public class CPHelper {
                 .sort(sortingMode.getMediaColumn())
                 .ascending(sortingOrder.isAscending());
 
-        if (Hawk.get("set_include_video", true)) {
+        if (Prefs.showVideos()) {
             query.selection(String.format("(%s=? or %s=?)",
                     MediaStore.Files.FileColumns.MEDIA_TYPE,
                     MediaStore.Files.FileColumns.MEDIA_TYPE));
@@ -204,7 +205,7 @@ public class CPHelper {
 
         return Observable.create(subscriber -> {
             File dir = new File(album.getPath());
-            File[] files = dir.listFiles(new ImageFileFilter(Hawk.get("set_include_video", true)));
+            File[] files = dir.listFiles(new ImageFileFilter(Prefs.showVideos()));
             try {
                 if (files != null && files.length > 0)
                     for (File file : files)
@@ -225,7 +226,7 @@ public class CPHelper {
                 .sort(sortingMode.getMediaColumn())
                 .ascending(sortingOrder.isAscending());
 
-        if (Hawk.get("set_include_video", true)) {
+        if (Prefs.showVideos()) {
             query.selection(String.format("(%s=? or %s=?) and %s=?",
                     MediaStore.Files.FileColumns.MEDIA_TYPE,
                     MediaStore.Files.FileColumns.MEDIA_TYPE,

--- a/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
@@ -38,6 +38,7 @@ import org.horaapps.leafpic.data.sort.SortingOrder;
 import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.Measure;
 import org.horaapps.leafpic.util.Security;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.leafpic.views.GridSpacingItemDecoration;
 import org.horaapps.liz.ThemeHelper;
 import org.horaapps.liz.ThemedActivity;
@@ -143,8 +144,8 @@ public class AlbumsFragment extends BaseFragment {
 
     public int columnsCount() {
         return getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT
-                ? Hawk.get("n_columns_folders", 2)
-                : Hawk.get("n_columns_folders_landscape", 3);
+                ? Prefs.getFolderColumnsPortrait()
+                : Prefs.getFolderColumnsLandscape();
     }
 
     private void updateToolbar() {
@@ -197,13 +198,13 @@ public class AlbumsFragment extends BaseFragment {
     public SortingMode sortingMode() {
         return adapter != null
                 ? adapter.sortingMode()
-                : AlbumsHelper.getSortingMode(getContext());
+                : AlbumsHelper.getSortingMode();
     }
 
     public SortingOrder sortingOrder() {
         return adapter != null
                 ? adapter.sortingOrder()
-                : AlbumsHelper.getSortingOrder(getContext());
+                : AlbumsHelper.getSortingOrder();
     }
 
     private HandlingAlbums db() {
@@ -332,25 +333,25 @@ public class AlbumsFragment extends BaseFragment {
 
             case R.id.name_sort_mode:
                 adapter.changeSortingMode(SortingMode.NAME);
-                AlbumsHelper.setSortingMode(getContext(), SortingMode.NAME);
+                AlbumsHelper.setSortingMode(SortingMode.NAME);
                 item.setChecked(true);
                 return true;
 
             case R.id.date_taken_sort_mode:
                 adapter.changeSortingMode(SortingMode.DATE);
-                AlbumsHelper.setSortingMode(getContext(), SortingMode.DATE);
+                AlbumsHelper.setSortingMode(SortingMode.DATE);
                 item.setChecked(true);
                 return true;
 
             case R.id.size_sort_mode:
                 adapter.changeSortingMode(SortingMode.SIZE);
-                AlbumsHelper.setSortingMode(getContext(), SortingMode.SIZE);
+                AlbumsHelper.setSortingMode(SortingMode.SIZE);
                 item.setChecked(true);
                 return true;
 
             case R.id.numeric_sort_mode:
                 adapter.changeSortingMode(SortingMode.NUMERIC);
-                AlbumsHelper.setSortingMode(getContext(), SortingMode.NUMERIC);
+                AlbumsHelper.setSortingMode(SortingMode.NUMERIC);
                 item.setChecked(true);
                 return true;
 
@@ -358,7 +359,7 @@ public class AlbumsFragment extends BaseFragment {
                 item.setChecked(!item.isChecked());
                 SortingOrder sortingOrder = SortingOrder.fromValue(item.isChecked());
                 adapter.changeSortingOrder(sortingOrder);
-                AlbumsHelper.setSortingOrder(getContext(), sortingOrder);
+                AlbumsHelper.setSortingOrder(sortingOrder);
                 return true;
 
             case R.id.exclude:

--- a/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
@@ -54,6 +54,7 @@ import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.Measure;
 import org.horaapps.leafpic.util.StringUtils;
 import org.horaapps.leafpic.util.file.DeleteException;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.leafpic.views.GridSpacingItemDecoration;
 import org.horaapps.liz.ThemeHelper;
 import org.horaapps.liz.ThemedActivity;
@@ -210,8 +211,8 @@ public class RvMediaFragment extends BaseFragment {
 
     public int columnsCount() {
         return getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT
-                ? Hawk.get("n_columns_media", 3)
-                : Hawk.get("n_columns_media_landscape", 4);
+                ? Prefs.getMediaColumnsPortrait()
+                : Prefs.getMediaColumnsLandscape();
     }
 
     private void updateToolbar() {

--- a/app/src/main/java/org/horaapps/leafpic/settings/CardViewStyleSetting.java
+++ b/app/src/main/java/org/horaapps/leafpic/settings/CardViewStyleSetting.java
@@ -20,6 +20,7 @@ import com.orhanobut.hawk.Hawk;
 import org.horaapps.leafpic.CardViewStyle;
 import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.util.StringUtils;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ColorPalette;
 import org.horaapps.liz.Theme;
 import org.horaapps.liz.ThemedActivity;
@@ -54,8 +55,8 @@ public class CardViewStyleSetting extends ThemedSetting {
         RadioButton rFlat = (RadioButton) dialogLayout.findViewById(R.id.radio_card_flat);
         RadioButton rMaterial = (RadioButton) dialogLayout.findViewById(R.id.radio_card_material);
 
-        chkShowMediaCount.setChecked(Hawk.get("show_media_count", true));
-        chkShowAlbumPath.setChecked(Hawk.get("show_album_path", false));
+        chkShowMediaCount.setChecked(Prefs.showMediaCount());
+        chkShowAlbumPath.setChecked(Prefs.showAlbumPath());
 
         getActivity().themeRadioButton(rCompact);
         getActivity().themeRadioButton(rFlat);
@@ -129,7 +130,7 @@ public class CardViewStyleSetting extends ThemedSetting {
             }
         });
 
-        switch (CardViewStyle.fromValue(Hawk.get("card_view_style", 0))) {
+        switch (Prefs.getCardStyle()) {
             case COMPACT: rCompact.setChecked(true); break;
             case FLAT: rFlat.setChecked(true); break;
             case MATERIAL: default: rMaterial.setChecked(true); break;
@@ -139,20 +140,22 @@ public class CardViewStyleSetting extends ThemedSetting {
         builder.setPositiveButton(getActivity().getString(R.string.ok_action).toUpperCase(), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                CardViewStyle cardViewStyle;
                 switch (rGroup.getCheckedRadioButtonId()) {
                     case R.id.radio_card_material:
                     default:
-                        Hawk.put("card_view_style", MATERIAL.getValue());
+                        cardViewStyle = MATERIAL;
                         break;
                     case R.id.radio_card_flat:
-                        Hawk.put("card_view_style", FLAT.getValue());
+                        cardViewStyle = FLAT;
                         break;
                     case R.id.radio_card_compact:
-                        Hawk.put("card_view_style", COMPACT.getValue());
+                        cardViewStyle = COMPACT;
                         break;
                 }
-                Hawk.put("show_media_count", chkShowMediaCount.isChecked());
-                Hawk.put("show_album_path", chkShowAlbumPath.isChecked());
+                Prefs.setCardStyle(cardViewStyle);
+                Prefs.setShowMediaCount(chkShowMediaCount.isChecked());
+                Prefs.setShowAlbumPath(chkShowAlbumPath.isChecked());
                 Toast.makeText(getActivity(), getActivity().getString(R.string.card_style_alert), Toast.LENGTH_SHORT).show();
             }
         });

--- a/app/src/main/java/org/horaapps/leafpic/settings/GeneralSetting.java
+++ b/app/src/main/java/org/horaapps/leafpic/settings/GeneralSetting.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 import com.orhanobut.hawk.Hawk;
 
 import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ThemedActivity;
 
 /**
@@ -54,11 +55,13 @@ public class GeneralSetting extends ThemedSetting {
         getActivity().themeSeekBar(barFoldersL);
         getActivity().themeSeekBar(barMediaL);
 
-        ///PORTRAIT
-        nColFolders.setText(String.valueOf(Hawk.get("n_columns_folders", 2)));
-        nColMedia.setText(String.valueOf(Hawk.get("n_columns_media", 3)));
-        barFolders.setProgress(Hawk.get("n_columns_folders", 2) - 1);
-        barMedia.setProgress(Hawk.get("n_columns_media", 3) - 2);
+        // Portrait Orientation
+        int folderColumnsPortrait = Prefs.getFolderColumnsPortrait();
+        int mediaColumnsPortrait = Prefs.getMediaColumnsPortrait();
+        nColFolders.setText(String.valueOf(folderColumnsPortrait));
+        nColMedia.setText(String.valueOf(mediaColumnsPortrait));
+        barFolders.setProgress(folderColumnsPortrait - 1);
+        barMedia.setProgress(mediaColumnsPortrait - 2);
         barFolders.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
@@ -81,11 +84,13 @@ public class GeneralSetting extends ThemedSetting {
             public void onStopTrackingTouch(SeekBar seekBar) {}
         });
 
-        ///LANDSCAPE
-        nColFoldersL.setText(String.valueOf(Hawk.get("n_columns_folders_landscape", 3)));
-        nColMediaL.setText(String.valueOf(Hawk.get("n_columns_media_landscape", 4)));
-        barFoldersL.setProgress(Hawk.get("n_columns_folders_landscape", 3) - 2);
-        barMediaL.setProgress(Hawk.get("n_columns_media_landscape", 4) - 3);
+        // Landscape Orientation
+        int folderColumnsLandscape = Prefs.getFolderColumnsLandscape();
+        int mediaColumnsLandscape = Prefs.getMediaColumnsLandscape();
+        nColFoldersL.setText(String.valueOf(folderColumnsLandscape));
+        nColMediaL.setText(String.valueOf(mediaColumnsLandscape));
+        barFoldersL.setProgress(folderColumnsLandscape - 2);
+        barMediaL.setProgress(mediaColumnsLandscape - 3);
         barFoldersL.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
@@ -115,10 +120,10 @@ public class GeneralSetting extends ThemedSetting {
                 int nMedia = Integer.parseInt(nColMedia.getText().toString());
                 int nFoldersL = Integer.parseInt(nColFoldersL.getText().toString());
                 int nMediaL = Integer.parseInt(nColMediaL.getText().toString());
-                Hawk.put("n_columns_folders", nFolders);
-                Hawk.put("n_columns_media", nMedia);
-                Hawk.put("n_columns_folders_landscape", nFoldersL);
-                Hawk.put("n_columns_media_landscape", nMediaL);
+                Prefs.setFolderColumnsPortrait(nFolders);
+                Prefs.setMediaColumnsPortrait(nMedia);
+                Prefs.setFolderColumnsLandscape(nFoldersL);
+                Prefs.setMediaColumnsLandscape(nMediaL);
             }
         });
         multiColumnDialogBuilder.setNegativeButton(getActivity().getString(R.string.cancel).toUpperCase(), null);

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/Defaults.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/Defaults.java
@@ -1,0 +1,31 @@
+package org.horaapps.leafpic.util.preferences;
+
+import org.horaapps.leafpic.CardViewStyle;
+import org.horaapps.leafpic.data.sort.SortingMode;
+import org.horaapps.leafpic.data.sort.SortingOrder;
+
+/**
+ * Class for storing Preference default values.
+ */
+public final class Defaults {
+
+    // Prevent class instantiation
+    private Defaults() {}
+
+    public static final int FOLDER_COLUMNS_PORTRAIT = 2;
+    public static final int FOLDER_COLUMNS_LANDSCAPE = 3;
+
+    public static final int MEDIA_COLUMNS_PORTRAIT = 3;
+    public static final int MEDIA_COLUMNS_LANDSCAPE = 4;
+
+    public static final int ALBUM_SORTING_MODE = SortingMode.DATE.getValue();
+    public static final int ALBUM_SORTING_ORDER = SortingOrder.DESCENDING.getValue();
+    public static final int CARD_STYLE = CardViewStyle.MATERIAL.getValue();
+
+    public static final boolean SHOW_VIDEOS = true;
+    public static final boolean SHOW_MEDIA_COUNT = true;
+    public static final boolean SHOW_ALBUM_PATH = false;
+
+    public static final int LAST_VERSION_CODE = 0;
+    public static final boolean SHOW_EASTER_EGG = false;
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/Keys.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/Keys.java
@@ -1,0 +1,28 @@
+package org.horaapps.leafpic.util.preferences;
+
+/**
+ * Class for Preference keys.
+ */
+public final class Keys {
+
+    // Prevent class instantiation
+    private Keys() {}
+
+    public static final String FOLDER_COLUMNS_PORTRAIT = "folder_columns_portrait";
+    public static final String FOLDER_COLUMNS_LANDSCAPE = "folder_columns_landscape";
+
+    public static final String MEDIA_COLUMNS_PORTRAIT = "media_columns_portrait";
+    public static final String MEDIA_COLUMNS_LANDSCAPE = "media_columns_landscape";
+
+    public static final String ALBUM_SORTING_MODE = "album_sorting_mode";
+    public static final String ALBUM_SORTING_ORDER = "album_sorting_order";
+
+    public static final String SHOW_VIDEOS = "show_videos";
+    public static final String SHOW_MEDIA_COUNT = "show_media_count";
+    public static final String SHOW_ALBUM_PATH = "show_album_path";
+
+    public static final String CARD_STYLE = "card_style";
+
+    public static final String LAST_VERSION_CODE = "last_version_code";
+    public static final String SHOW_EASTER_EGG = "show_easter_egg";
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/Prefs.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/Prefs.java
@@ -1,0 +1,228 @@
+package org.horaapps.leafpic.util.preferences;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import org.horaapps.leafpic.CardViewStyle;
+import org.horaapps.leafpic.data.sort.SortingMode;
+import org.horaapps.leafpic.data.sort.SortingOrder;
+
+/**
+ * Class for storing & retrieving application data.
+ * <p>
+ * Abstracts clients from from DB / SharedPreferences / Hawk.
+ */
+public class Prefs {
+
+    private static SharedPrefs sharedPrefs;
+
+    /**
+     * Initialise the Prefs object for future static usage.
+     * Make sure to initialise this in Application class.
+     *
+     * @param context The context to initialise with.
+     */
+    public static void init(@NonNull Context context) {
+        if (sharedPrefs != null) {
+            throw new RuntimeException("Prefs has already been instantiated");
+        }
+        sharedPrefs = new SharedPrefs(context);
+    }
+
+    /********** GETTERS **********/
+
+    /**
+     * Get number of folder columns to display in Portrait orientation
+     */
+    public static int getFolderColumnsPortrait() {
+        return getPrefs().get(Keys.FOLDER_COLUMNS_PORTRAIT, Defaults.FOLDER_COLUMNS_PORTRAIT);
+    }
+
+    /**
+     * Get number of folder columns to display in Landscape orientation
+     */
+    public static int getFolderColumnsLandscape() {
+        return getPrefs().get(Keys.FOLDER_COLUMNS_LANDSCAPE, Defaults.FOLDER_COLUMNS_LANDSCAPE);
+    }
+
+    /**
+     * Get number of media columns to display in Portrait orientation
+     */
+    public static int getMediaColumnsPortrait() {
+        return getPrefs().get(Keys.MEDIA_COLUMNS_PORTRAIT, Defaults.MEDIA_COLUMNS_PORTRAIT);
+    }
+
+    /**
+     * Get number of media columns to display in Landscape orientation
+     */
+    public static int getMediaColumnsLandscape() {
+        return getPrefs().get(Keys.MEDIA_COLUMNS_LANDSCAPE, Defaults.MEDIA_COLUMNS_LANDSCAPE);
+    }
+
+    /**
+     * Get the sorting mode (Name / Date / Size / Type / Numeric) for albums.
+     */
+    @NonNull
+    public static SortingMode getAlbumSortingMode() {
+        return SortingMode.fromValue(
+                getPrefs().get(Keys.ALBUM_SORTING_MODE, Defaults.ALBUM_SORTING_MODE));
+    }
+
+    /**
+     * Get the sorting order (Ascending / Descending) for albums.
+     */
+    @NonNull
+    public static SortingOrder getAlbumSortingOrder() {
+        return SortingOrder.fromValue(
+                getPrefs().get(Keys.ALBUM_SORTING_ORDER, Defaults.ALBUM_SORTING_ORDER));
+    }
+
+    /**
+     * Should display video files in media.
+     */
+    public static boolean showVideos() {
+        return getPrefs().get(Keys.SHOW_VIDEOS, Defaults.SHOW_VIDEOS);
+    }
+
+    /**
+     * Should display count of media.
+     */
+    public static boolean showMediaCount() {
+        return getPrefs().get(Keys.SHOW_MEDIA_COUNT, Defaults.SHOW_MEDIA_COUNT);
+    }
+
+    /**
+     * Should display path of albums.
+     */
+    public static boolean showAlbumPath() {
+        return getPrefs().get(Keys.SHOW_ALBUM_PATH, Defaults.SHOW_ALBUM_PATH);
+    }
+
+    /**
+     * Should show the Emoji Easter Egg.
+     */
+    public static boolean showEasterEgg() {
+        return getPrefs().get(Keys.SHOW_EASTER_EGG, Defaults.SHOW_EASTER_EGG);
+    }
+
+    /**
+     * Get the Card Style (Material / Flat / Compact)
+     */
+    @NonNull
+    public static CardViewStyle getCardStyle() {
+        return CardViewStyle.fromValue(
+                getPrefs().get(Keys.CARD_STYLE, Defaults.CARD_STYLE));
+    }
+
+    public static int getLastVersionCode() {
+        return getPrefs().get(Keys.LAST_VERSION_CODE, Defaults.LAST_VERSION_CODE);
+    }
+
+    /********** SETTERS **********/
+
+    /**
+     * Set the number of folder columns in Portrait orientation.
+     */
+    public static void setFolderColumnsPortrait(int value) {
+        getPrefs().put(Keys.FOLDER_COLUMNS_PORTRAIT, value);
+    }
+
+    /**
+     * Set the number of folder columns in Landscape orientation.
+     */
+    public static void setFolderColumnsLandscape(int value) {
+        getPrefs().put(Keys.FOLDER_COLUMNS_LANDSCAPE, value);
+    }
+
+    /**
+     * Set the number of media columns in Portrait orientation.
+     */
+    public static void setMediaColumnsPortrait(int value) {
+        getPrefs().put(Keys.MEDIA_COLUMNS_PORTRAIT, value);
+    }
+
+    /**
+     * Set the number of media columns in Landscape orientation.
+     */
+    public static void setMediaColumnsLandscape(int value) {
+        getPrefs().put(Keys.MEDIA_COLUMNS_LANDSCAPE, value);
+    }
+
+    /**
+     * Set the Sorting Mode for albums (Name / Size / etc)
+     */
+    public static void setAlbumSortingMode(@NonNull SortingMode sortingMode) {
+        getPrefs().put(Keys.ALBUM_SORTING_MODE, sortingMode.getValue());
+    }
+
+    /**
+     * Set the Sorting Order for albums (Ascending / Descending)
+     */
+    public static void setAlbumSortingOrder(@NonNull SortingOrder sortingOrder) {
+        getPrefs().put(Keys.ALBUM_SORTING_ORDER, sortingOrder.getValue());
+    }
+
+    /**
+     * Set show video files in media collection.
+     */
+    public static void setShowVideos(boolean value) {
+        getPrefs().put(Keys.SHOW_VIDEOS, value);
+    }
+
+    /**
+     * Set show the media count.
+     */
+    public static void setShowMediaCount(boolean value) {
+        getPrefs().put(Keys.SHOW_MEDIA_COUNT, value);
+    }
+
+    /**
+     * Set show the full album path.
+     */
+    public static void setShowAlbumPath(boolean value) {
+        getPrefs().put(Keys.SHOW_ALBUM_PATH, value);
+    }
+
+    /**
+     * Set the Card Style (Material / Flat / Compact)
+     */
+    public static void setCardStyle(@NonNull CardViewStyle cardStyle) {
+        getPrefs().put(Keys.CARD_STYLE, cardStyle.getValue());
+    }
+
+    /**
+     * Set the last version code of Application.
+     */
+    public static void setLastVersionCode(int value) {
+        getPrefs().put(Keys.LAST_VERSION_CODE, value);
+    }
+
+    /**
+     * Set show the Emoji Easter Egg.
+     */
+    public static void setShowEasterEgg(boolean value) {
+        getPrefs().put(Keys.SHOW_EASTER_EGG, value);
+    }
+
+    // ***** TODO Calvin: These methods does not belong here, DO NOT expose generic methods to clients
+
+    @Deprecated
+    public static void setToggleValue(@NonNull String key, boolean value) {
+        getPrefs().put(key, value);
+    }
+
+    @Deprecated
+    public static boolean getToggleValue(@NonNull String key, boolean defaultValue) {
+        return getPrefs().get(key, defaultValue);
+    }
+
+    // ***** Remove these methods when SettingWithSwitchView is refactored.
+
+    @NonNull
+    private static SharedPrefs getPrefs() {
+        if (sharedPrefs == null) {
+            throw new RuntimeException("Prefs has not been instantiated. Call init() with context");
+        }
+        return sharedPrefs;
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/SharedPrefs.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/SharedPrefs.java
@@ -1,0 +1,43 @@
+package org.horaapps.leafpic.util.preferences;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+
+/**
+ * Android's SharedPreferences for storing key-value pairs.
+ * DO NOT INSTANTIATE THIS CLASS - Use {@link Prefs} for your needs.
+ */
+/* package */ final class SharedPrefs {
+
+    private static final String PREFERENCES_NAME = "org.horaapps.leafpic.SHARED_PREFS";
+    private static final int PREFERENCES_MODE = Context.MODE_PRIVATE;
+
+    private final SharedPreferences sharedPrefs;
+
+    /* package */ SharedPrefs(@NonNull Context context) {
+        sharedPrefs = context.getApplicationContext()
+                .getSharedPreferences(PREFERENCES_NAME, PREFERENCES_MODE);
+    }
+
+    @NonNull
+    private SharedPreferences.Editor getEditor() {
+        return sharedPrefs.edit();
+    }
+
+    /* package */ int get(@NonNull String key, int defaultValue) {
+        return sharedPrefs.getInt(key, defaultValue);
+    }
+
+    /* package */ void put(@NonNull String key, int value) {
+        getEditor().putInt(key, value).commit();
+    }
+
+    /* package */ boolean get(@NonNull String key, boolean defaultValue) {
+        return sharedPrefs.getBoolean(key, defaultValue);
+    }
+
+    /* package */ void put(@NonNull String key, boolean value) {
+        getEditor().putBoolean(key, value).commit();
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/views/SettingWithSwitchView.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/SettingWithSwitchView.java
@@ -12,9 +12,8 @@ import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import com.orhanobut.hawk.Hawk;
-
 import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ThemeHelper;
 import org.horaapps.liz.Themed;
 import org.horaapps.liz.ThemedActivity;
@@ -110,14 +109,13 @@ public class SettingWithSwitchView extends FrameLayout implements View.OnClickLi
     }
 
     public boolean isChecked() {
-        return Hawk.get(preferenceKey, defaultValue);
+        return Prefs.getToggleValue(preferenceKey, defaultValue);
     }
 
-    public boolean toggle() {
-        Hawk.put(preferenceKey, !isChecked());
+    public void toggle() {
+        Prefs.setToggleValue(preferenceKey, !isChecked());
         boolean checked = isChecked();
         toggle.setChecked(checked);
-        return checked;
     }
 
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -311,7 +311,7 @@
                         android:layout_height="wrap_content"
                         app:settingCaption="@string/include_video_sub"
                         app:settingIcon="gmd-videocam"
-                        app:settingPreferenceKey="@string/preference_swipe_direction_inverted"
+                        app:settingPreferenceKey="@string/preference_include_video"
                         app:settingTitle="@string/include_video"/>
 
                     <org.horaapps.leafpic.views.SettingWithSwitchView

--- a/app/src/main/res/values/preferences-key.xml
+++ b/app/src/main/res/values/preferences-key.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="preference_internal_player">set_internal_player</string>
-    <string name="preference_include_video">set_include_video</string>
+    <string name="preference_include_video">show_videos</string>
     <string name="preference_swipe_direction_inverted">swipe_opposite</string>
     <string name="preference_video_instant_play">video_instant_play</string>
     <string name="preference_auto_update_media">auto_update_media</string>


### PR DESCRIPTION
- Added SharedPrefs class to work with Android's SharedPreferences.
- Added Prefs class to abstract get / set logic from clients.
  Retrieving default values is also taken care of here.
- Added Defaults class to hold Preference Default values. Moved out
  hardcoded defaults to this class.
- Added Keys class to hold Preference keys. Moved out hardcoded
  keys for get / set to this class.
- Fixed "Include Video" setting key.
- Minor refactoring at various places.