### PR TITLE
Fixed a crash when going from Media > Album view

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -12,6 +12,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
@@ -51,44 +53,60 @@ import java.util.Locale;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
-
+/**
+ * The Main Activity used to display Albums / Media.
+ */
 public class MainActivity extends SharedMediaActivity {
 
+    public static final String ARGS_PICK_MODE = "pick_mode";
 
-    AlbumsFragment albumsFragment = new AlbumsFragment();
-    RvMediaFragment rvMediaFragment = new RvMediaFragment();
+    private static final String SAVE_ALBUM_MODE = "album_mode";
 
-    @BindView(R.id.fab_camera)
-    FloatingActionButton fab;
-    @BindView(R.id.drawer_layout)
-    DrawerLayout drawer;
-    @BindView(R.id.toolbar)
-    Toolbar toolbar;
-    @BindView(R.id.coordinator_main_layout)
-    CoordinatorLayout mainLayout;
+    @BindView(R.id.fab_camera) FloatingActionButton fab;
+    @BindView(R.id.drawer_layout) DrawerLayout drawer;
+    @BindView(R.id.toolbar) Toolbar toolbar;
+    @BindView(R.id.coordinator_main_layout) CoordinatorLayout mainLayout;
+
+    private AlbumsFragment albumsFragment;
+    private RvMediaFragment rvMediaFragment = new RvMediaFragment();
 
     private boolean pickMode = false;
-    private boolean albumsMode = true;
+    private boolean albumsMode;
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
+    public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         ButterKnife.bind(this);
 
-        pickMode = getIntent().getBooleanExtra(SplashScreen.PICK_MODE, false);
-
-        if (savedInstanceState != null)
-            return;
-
         initUi();
+        pickMode = getIntent().getBooleanExtra(ARGS_PICK_MODE, false);
 
-        getSupportFragmentManager()
-                .beginTransaction()
-                .replace(R.id.content, albumsFragment, "albums")
-                .addToBackStack(null)
-                .commit();
+        if (savedInstanceState == null) {
+            // Add AlbumsFragment to UI
+            albumsFragment = new AlbumsFragment();
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.content, albumsFragment, AlbumsFragment.TAG)
+                    .addToBackStack(null)
+                    .commit();
 
+            return;
+        }
+
+        // We have some instance state
+        restoreState(savedInstanceState);
+        albumsFragment = (AlbumsFragment) getSupportFragmentManager().findFragmentByTag(AlbumsFragment.TAG);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(SAVE_ALBUM_MODE, albumsMode);
+        super.onSaveInstanceState(outState);
+    }
+
+    private void restoreState(@NonNull Bundle savedInstance) {
+        albumsMode = savedInstance.getBoolean(SAVE_ALBUM_MODE, true);
     }
 
     private void displayAlbums(boolean hidden) {

--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -56,7 +56,7 @@ import butterknife.ButterKnife;
 /**
  * The Main Activity used to display Albums / Media.
  */
-public class MainActivity extends SharedMediaActivity {
+public class MainActivity extends SharedMediaActivity implements RvMediaFragment.MediaClickListener {
 
     public static final String ARGS_PICK_MODE = "pick_mode";
 
@@ -91,8 +91,6 @@ public class MainActivity extends SharedMediaActivity {
                     .addToBackStack(null)
                     .commit();
 
-            rvMediaFragment = new RvMediaFragment();
-
             return;
         }
 
@@ -101,6 +99,7 @@ public class MainActivity extends SharedMediaActivity {
 
         if (!albumsMode) {
             rvMediaFragment = (RvMediaFragment) getSupportFragmentManager().findFragmentByTag(RvMediaFragment.TAG);
+            rvMediaFragment.setListener(this);
         }
         albumsFragment = (AlbumsFragment) getSupportFragmentManager().findFragmentByTag(AlbumsFragment.TAG);
     }
@@ -122,51 +121,46 @@ public class MainActivity extends SharedMediaActivity {
     }
 
     public void displayMedia(Album album) {
+        rvMediaFragment = RvMediaFragment.make(album);
         albumsMode = false;
         drawer.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
 
-        rvMediaFragment.setListener(new RvMediaFragment.MediaClickListener() {
-            @Override
-            public void onCreated() {
-                rvMediaFragment.loadAlbum(album);
-            }
-
-            @Override
-            public void onClick(Album album, ArrayList<Media> media, int position) {
-
-                if (!pickMode) {
-                    Intent intent = new Intent(getApplicationContext(), SingleMediaActivity.class);
-                    intent.putExtra("album", album);
-                    try {
-                        intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM);
-                        intent.putExtra("media", media);
-                        intent.putExtra("position", position);
-                        startActivity(intent);
-                    } catch (Exception e) {
-                        intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM_LAZY);
-                        intent.putExtra("media", media.get(position));
-                        startActivity(intent);
-                    }
-
-                } else {
-
-                    Media m = media.get(position);
-                    Uri uri = LegacyCompatFileProvider.getUri(getApplicationContext(), m.getFile());
-                    Intent res = new Intent();
-                    res.setData(uri);
-                    res.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    setResult(RESULT_OK, res);
-                    finish();
-                }
-            }
-        });
-
+        rvMediaFragment.setListener(this);
 
         getSupportFragmentManager()
                 .beginTransaction()
                 .replace(R.id.content, rvMediaFragment, RvMediaFragment.TAG)
                 .addToBackStack(null)
                 .commit();
+    }
+
+    @Override
+    public void onClick(Album album, ArrayList<Media> media, int position) {
+
+        if (!pickMode) {
+            Intent intent = new Intent(getApplicationContext(), SingleMediaActivity.class);
+            intent.putExtra("album", album);
+            try {
+                intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM);
+                intent.putExtra("media", media);
+                intent.putExtra("position", position);
+                startActivity(intent);
+            } catch (Exception e) {
+                intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM_LAZY);
+                intent.putExtra("media", media.get(position));
+                startActivity(intent);
+            }
+
+        } else {
+
+            Media m = media.get(position);
+            Uri uri = LegacyCompatFileProvider.getUri(getApplicationContext(), m.getFile());
+            Intent res = new Intent();
+            res.setData(uri);
+            res.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            setResult(RESULT_OK, res);
+            finish();
+        }
     }
 
 

--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -68,7 +68,7 @@ public class MainActivity extends SharedMediaActivity {
     @BindView(R.id.coordinator_main_layout) CoordinatorLayout mainLayout;
 
     private AlbumsFragment albumsFragment;
-    private RvMediaFragment rvMediaFragment = new RvMediaFragment();
+    private RvMediaFragment rvMediaFragment;
 
     private boolean pickMode = false;
     private boolean albumsMode;
@@ -91,11 +91,17 @@ public class MainActivity extends SharedMediaActivity {
                     .addToBackStack(null)
                     .commit();
 
+            rvMediaFragment = new RvMediaFragment();
+
             return;
         }
 
         // We have some instance state
         restoreState(savedInstanceState);
+
+        if (!albumsMode) {
+            rvMediaFragment = (RvMediaFragment) getSupportFragmentManager().findFragmentByTag(RvMediaFragment.TAG);
+        }
         albumsFragment = (AlbumsFragment) getSupportFragmentManager().findFragmentByTag(AlbumsFragment.TAG);
     }
 
@@ -158,7 +164,7 @@ public class MainActivity extends SharedMediaActivity {
 
         getSupportFragmentManager()
                 .beginTransaction()
-                .replace(R.id.content, rvMediaFragment, "media")
+                .replace(R.id.content, rvMediaFragment, RvMediaFragment.TAG)
                 .addToBackStack(null)
                 .commit();
     }
@@ -477,7 +483,7 @@ public class MainActivity extends SharedMediaActivity {
                 else finish();
             }
         } else {
-            if (!((BaseFragment) getSupportFragmentManager().findFragmentByTag("media")).onBackPressed())
+            if (!((BaseFragment) getSupportFragmentManager().findFragmentByTag(RvMediaFragment.TAG)).onBackPressed())
                 goBackToAlbums();
         }
     }

--- a/app/src/main/java/org/horaapps/leafpic/activities/SplashScreen.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SplashScreen.java
@@ -38,7 +38,6 @@ public class SplashScreen extends SharedMediaActivity {
     private static final int PICK_MEDIA_REQUEST = 44;
 
     final static String CONTENT = "content";
-    final static String PICK_MODE = "pick_mode";
 
     final static int ALBUMS_PREFETCHED = 2376;
     final static int PHOTOS_PREFETCHED = 2567;
@@ -93,7 +92,7 @@ public class SplashScreen extends SharedMediaActivity {
         Intent intent = new Intent(SplashScreen.this, MainActivity.class);
 
         if (pickMode) {
-            intent.putExtra(SplashScreen.PICK_MODE, pickMode);
+            intent.putExtra(MainActivity.ARGS_PICK_MODE, pickMode);
             startActivityForResult(intent, PICK_MEDIA_REQUEST);
         } else {
             startActivity(intent);

--- a/app/src/main/java/org/horaapps/leafpic/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/AlbumsAdapter.java
@@ -187,12 +187,21 @@ public class AlbumsAdapter extends ThemedAdapter<AlbumsAdapter.ViewHolder> {
         notifyDataSetChanged();
     }
 
-    public void clearSelected() {
-        for (int i = 0; i < albums.size(); i++)
-            if (albums.get(i).setSelected(false))
+    public boolean clearSelected() {
+
+        boolean changed = true;
+        for (int i = 0; i < albums.size(); i++) {
+            boolean b = albums.get(i).setSelected(false);
+            if (b)
                 notifyItemChanged(i);
+            changed &= b;
+        }
+
         selectedCount = 0;
-        onChangeSelectedSubject.onNext(Album.getEmptyAlbum());
+
+        if (changed)
+            onChangeSelectedSubject.onNext(Album.getEmptyAlbum());
+        return changed;
     }
 
     public void forceSelectedCount(int count) {

--- a/app/src/main/java/org/horaapps/leafpic/adapters/MediaAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/MediaAdapter.java
@@ -134,12 +134,19 @@ public class MediaAdapter extends ThemedAdapter<MediaAdapter.ViewHolder> {
         onChangeSelectedSubject.onNext(new Media());
     }
 
-    public void clearSelected() {
-        for (int i = 0; i < media.size(); i++)
-            if (media.get(i).setSelected(false))
+    public boolean clearSelected() {
+        boolean changed = true;
+        for (int i = 0; i < media.size(); i++) {
+            boolean b = media.get(i).setSelected(false);
+            if (b)
                 notifyItemChanged(i);
+            changed &= b;
+        }
+
         selectedCount = 0;
-        onChangeSelectedSubject.onNext(new Media());
+        if (changed)
+            onChangeSelectedSubject.onNext(new Media());
+        return changed;
     }
 
     @Override

--- a/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
@@ -58,7 +58,7 @@ import jp.wasabeef.recyclerview.animators.LandingAnimator;
 
 public class AlbumsFragment extends BaseFragment {
 
-    private static final String TAG = "asd";
+    public static final String TAG = "AlbumsFragment";
 
     @BindView(R.id.albums) RecyclerView rv;
     @BindView(R.id.swipe_refresh) SwipeRefreshLayout refresh;

--- a/app/src/main/java/org/horaapps/leafpic/fragments/BaseFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/BaseFragment.java
@@ -9,11 +9,31 @@ import org.horaapps.liz.ThemedFragment;
  */
 
 public abstract class BaseFragment extends ThemedFragment implements IFragment, Themed {
+
+    private EditModeListener editModeListener;
+    private NothingToShowListener nothingToShowListener;
+
     public boolean onBackPressed(){
         if (editMode()){
             clearSelected();
             return true;
         }
         return false;
+    }
+
+    public EditModeListener getEditModeListener() {
+        return editModeListener;
+    }
+
+    public void setEditModeListener(EditModeListener editModeListener) {
+        this.editModeListener = editModeListener;
+    }
+
+    public NothingToShowListener getNothingToShowListener() {
+        return nothingToShowListener;
+    }
+
+    public void setNothingToShowListener(NothingToShowListener nothingToShowListener) {
+        this.nothingToShowListener = nothingToShowListener;
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/EditModeListener.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/EditModeListener.java
@@ -1,0 +1,13 @@
+package org.horaapps.leafpic.fragments;
+
+import android.view.View;
+
+import javax.annotation.Nullable;
+
+/**
+ * Created by dnld on 12/16/17.
+ */
+
+public interface EditModeListener {
+    void changedEditMode(boolean editMode, int selected, int total, @Nullable View.OnClickListener listener, @Nullable String title);
+}

--- a/app/src/main/java/org/horaapps/leafpic/fragments/IFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/IFragment.java
@@ -6,5 +6,6 @@ package org.horaapps.leafpic.fragments;
 
 public interface IFragment {
     boolean editMode();
-    void clearSelected();
+
+    boolean clearSelected();
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/NothingToShowListener.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/NothingToShowListener.java
@@ -1,0 +1,9 @@
+package org.horaapps.leafpic.fragments;
+
+/**
+ * Created by dnld on 12/16/17.
+ */
+
+public interface NothingToShowListener {
+    void changedNothingToShow(boolean nothingToShow);
+}

--- a/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
@@ -77,7 +77,7 @@ import jp.wasabeef.recyclerview.animators.LandingAnimator;
 public class RvMediaFragment extends BaseFragment {
 
     public static final String TAG = "RvMediaFragment";
-    private final String BUNDLE_ALBUM = "album";
+    private static final String BUNDLE_ALBUM = "album";
 
     @BindView(R.id.media) RecyclerView rv;
     @BindView(R.id.swipe_refresh) SwipeRefreshLayout refresh;
@@ -94,11 +94,19 @@ public class RvMediaFragment extends BaseFragment {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
         if (savedInstanceState == null) {
-            album = Album.getEmptyAlbum();
+            album = getArguments().getParcelable(BUNDLE_ALBUM);
             return;
         }
 
         album = savedInstanceState.getParcelable(BUNDLE_ALBUM);
+    }
+
+    public static RvMediaFragment make(Album album) {
+        RvMediaFragment fragment = new RvMediaFragment();
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(BUNDLE_ALBUM, album);
+        fragment.setArguments(bundle);
+        return fragment;
     }
 
     @Override
@@ -119,7 +127,7 @@ public class RvMediaFragment extends BaseFragment {
         loadAlbum(album);
     }
 
-    public void loadAlbum(Album album) {
+    private void loadAlbum(Album album) {
         this.album = album;
         adapter.setupFor(album);
         CPHelper.getMedia(getContext(), album)
@@ -146,8 +154,6 @@ public class RvMediaFragment extends BaseFragment {
     }
 
     public interface MediaClickListener {
-        void onCreated();
-
         void onClick(Album album, ArrayList<Media> media, int position);
     }
 
@@ -159,7 +165,7 @@ public class RvMediaFragment extends BaseFragment {
 
     @Nullable
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
 
         View v = inflater.inflate(R.layout.fragment_rv_media, container, false);
         ButterKnife.bind(this, v);
@@ -194,17 +200,13 @@ public class RvMediaFragment extends BaseFragment {
         refresh.setOnRefreshListener(this::reload);
         rv.setAdapter(adapter);
 
-        if (savedInstanceState != null) {
-            reload();
-        }
         return v;
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        if (listener != null)
-            listener.onCreated();
+        reload();
     }
 
 

--- a/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
@@ -10,6 +10,7 @@ import android.graphics.PorterDuffColorFilter;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.AlertDialog;
@@ -75,6 +76,9 @@ import jp.wasabeef.recyclerview.animators.LandingAnimator;
 
 public class RvMediaFragment extends BaseFragment {
 
+    public static final String TAG = "RvMediaFragment";
+    private final String BUNDLE_ALBUM = "album";
+
     @BindView(R.id.media) RecyclerView rv;
     @BindView(R.id.swipe_refresh) SwipeRefreshLayout refresh;
 
@@ -83,14 +87,18 @@ public class RvMediaFragment extends BaseFragment {
 
     private MainActivity act;
 
-    private Album album = Album.getEmptyAlbum();
+    private Album album;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+        if (savedInstanceState == null) {
+            album = Album.getEmptyAlbum();
+            return;
+        }
 
-        //album = getArguments().getParcelable("album");
+        album = savedInstanceState.getParcelable(BUNDLE_ALBUM);
     }
 
     @Override
@@ -107,7 +115,7 @@ public class RvMediaFragment extends BaseFragment {
         setUpColumns();
     }
 
-    private void display() {
+    private void reload() {
         loadAlbum(album);
     }
 
@@ -131,6 +139,12 @@ public class RvMediaFragment extends BaseFragment {
 
     }
 
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putParcelable(BUNDLE_ALBUM, album);
+        super.onSaveInstanceState(outState);
+    }
+
     public interface MediaClickListener {
         void onCreated();
 
@@ -147,7 +161,7 @@ public class RvMediaFragment extends BaseFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
 
-        View v = inflater.inflate(R.layout.fragment_rv_media, null);
+        View v = inflater.inflate(R.layout.fragment_rv_media, container, false);
         ButterKnife.bind(this, v);
 
         int spanCount = columnsCount();
@@ -177,8 +191,12 @@ public class RvMediaFragment extends BaseFragment {
                     getActivity().invalidateOptionsMenu();
                 });
 
-        refresh.setOnRefreshListener(this::display);
+        refresh.setOnRefreshListener(this::reload);
         rv.setAdapter(adapter);
+
+        if (savedInstanceState != null) {
+            reload();
+        }
         return v;
     }
 
@@ -293,25 +311,25 @@ public class RvMediaFragment extends BaseFragment {
             case R.id.all_media_filter:
                 album.setFilterMode(FilterMode.ALL);
                 item.setChecked(true);
-                display();
+                reload();
                 return true;
 
             case R.id.video_media_filter:
                 album.setFilterMode(FilterMode.VIDEO);
                 item.setChecked(true);
-                display();
+                reload();
                 return true;
 
             case R.id.image_media_filter:
                 album.setFilterMode(FilterMode.IMAGES);
                 item.setChecked(true);
-                display();
+                reload();
                 return true;
 
             case R.id.gifs_media_filter:
                 album.setFilterMode(FilterMode.GIF);
                 item.setChecked(true);
-                display();
+                reload();
                 return true;
 
             case R.id.sharePhotos:


### PR DESCRIPTION
Bugs:
- When a user goes from Album > Media view, then minimizes the
  application and the activity gets destroyed in background,
  the resumed activity crashes when pressing back.
- When a user minimizes the application and the activity gets
  destroyed, the resumed app has non-working Navigation Drawer.

Fixes:
- Save 'albumsMode' state in onSaveInstanceState() so that
  we know if the destroyed activity was in Album / Media mode.
- Initialised the UI and set onClickListeners for Navigation
  Drawer irrespective of savedInstanceState.

Quirks:
- The activity does not crash and navigates correctly to previous
  screen, however the media does not show up when resuming.