### PR TITLE
Rotate based on exif

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,8 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
 
+    //exifInterface
+    implementation "com.android.support:exifinterface:$supportVersion"
     // google & support
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:cardview-v7:$supportVersion"

--- a/app/src/main/java/org/horaapps/leafpic/fragments/ImageFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/ImageFragment.java
@@ -12,6 +12,7 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
 import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.activities.SingleMediaActivity;
 import org.horaapps.leafpic.data.Media;
+import org.horaapps.leafpic.util.BitmapUtils;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -51,7 +52,8 @@ public class ImageFragment extends Fragment {
         view = inflater.inflate(R.layout.fragment_photo, container, false);
         unbinder = ButterKnife.bind(this, view);
 
-        subsampling.setOrientation(SubsamplingScaleImageView.ORIENTATION_0);
+        int orientation = BitmapUtils.getOrientation(img.getPath());
+        subsampling.setOrientation(orientation);
         subsampling.setImage(ImageSource.uri(img.getUri()));
         subsampling.setOnClickListener(view -> ((SingleMediaActivity) getActivity()).toggleSystemUI());
 

--- a/app/src/main/java/org/horaapps/leafpic/fragments/ImageFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/ImageFragment.java
@@ -2,6 +2,7 @@ package org.horaapps.leafpic.fragments;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +14,8 @@ import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.activities.SingleMediaActivity;
 import org.horaapps.leafpic.data.Media;
 import org.horaapps.leafpic.util.BitmapUtils;
+
+import java.io.InputStream;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -52,7 +55,7 @@ public class ImageFragment extends Fragment {
         view = inflater.inflate(R.layout.fragment_photo, container, false);
         unbinder = ButterKnife.bind(this, view);
 
-        int orientation = BitmapUtils.getOrientation(img.getPath());
+        int orientation = BitmapUtils.getOrientation(img.getUri(),this.getContext());
         subsampling.setOrientation(orientation);
         subsampling.setImage(ImageSource.uri(img.getUri()));
         subsampling.setOnClickListener(view -> ((SingleMediaActivity) getActivity()).toggleSystemUI());

--- a/app/src/main/java/org/horaapps/leafpic/util/BitmapUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/BitmapUtils.java
@@ -43,8 +43,9 @@ public class BitmapUtils {
 
     public static int getOrientation(Uri imgPath, Context ctx){
         ExifInterface exif;
+        InputStream in = null;
         try {
-            InputStream in = ctx.getContentResolver().openInputStream(imgPath);
+            in = ctx.getContentResolver().openInputStream(imgPath);
             exif = new ExifInterface( in );
             int orientation = exif.getAttributeInt( ExifInterface.TAG_ORIENTATION, 1 );
             int rotation = 0;
@@ -65,6 +66,12 @@ public class BitmapUtils {
             return rotation;
         } catch ( IOException e ) {
             e.printStackTrace();
+        }finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignored) {}
+            }
         }
         return 0;
     }

--- a/app/src/main/java/org/horaapps/leafpic/util/BitmapUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/BitmapUtils.java
@@ -3,6 +3,11 @@ package org.horaapps.leafpic.util;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
+import android.media.ExifInterface;
+
+import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
+
+import java.io.IOException;
 
 /**
  * Created by dnld on 3/25/17.
@@ -31,5 +36,32 @@ public class BitmapUtils {
             );
         }
         return dstBmp;
+    }
+
+    public static int getOrientation(String imgPath){
+        ExifInterface exif;
+        try {
+            exif = new ExifInterface( imgPath );
+            int orientation = exif.getAttributeInt( ExifInterface.TAG_ORIENTATION, 1 );
+            int rotation = 0;
+            switch ( orientation ) {
+                case ExifInterface.ORIENTATION_ROTATE_180:
+                    rotation = SubsamplingScaleImageView.ORIENTATION_180;
+                    break;
+                case ExifInterface.ORIENTATION_ROTATE_90:
+                    rotation = SubsamplingScaleImageView.ORIENTATION_90;
+                    break;
+                case ExifInterface.ORIENTATION_ROTATE_270:
+                    rotation = SubsamplingScaleImageView.ORIENTATION_270;
+                    break;
+                default:
+                    rotation = SubsamplingScaleImageView.ORIENTATION_0;
+                    break;
+            }
+            return rotation;
+        } catch ( IOException e ) {
+            e.printStackTrace();
+        }
+        return 0;
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/util/BitmapUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/BitmapUtils.java
@@ -1,13 +1,16 @@
 package org.horaapps.leafpic.util;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.media.ExifInterface;
+import android.support.media.ExifInterface;
+import android.net.Uri;
 
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Created by dnld on 3/25/17.
@@ -38,10 +41,11 @@ public class BitmapUtils {
         return dstBmp;
     }
 
-    public static int getOrientation(String imgPath){
+    public static int getOrientation(Uri imgPath, Context ctx){
         ExifInterface exif;
         try {
-            exif = new ExifInterface( imgPath );
+            InputStream in = ctx.getContentResolver().openInputStream(imgPath);
+            exif = new ExifInterface( in );
             int orientation = exif.getAttributeInt( ExifInterface.TAG_ORIENTATION, 1 );
             int rotation = 0;
             switch ( orientation ) {


### PR DESCRIPTION
This fixes https://github.com/HoraApps/LeafPic/issues/118 or at least most cases.

Exif is tricky and some phones even take pictures mirrored and you're supposed to flip them horizontally/vertically based on the exif value. 
[Here's](http://sylvana.net/jpegcrop/exif_orientation.html) a good reference about this issue.

Also, I added the function on the bitmaputils class but it doesn't ever use a bitmap so I'm sorry please let me know if I should move it somewher eelse😃 