### PR TITLE
Fixed some crashes, refactoring

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -170,15 +170,17 @@ public class MainActivity extends SharedMediaActivity implements
 
         if (!pickMode) {
             Intent intent = new Intent(getApplicationContext(), SingleMediaActivity.class);
-            intent.putExtra("album", album);
+            intent.putExtra(SingleMediaActivity.EXTRA_ARGS_ALBUM, album);
             try {
                 intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM);
-                intent.putExtra("media", media);
-                intent.putExtra("position", position);
+                intent.putExtra(SingleMediaActivity.EXTRA_ARGS_MEDIA, media);
+                intent.putExtra(SingleMediaActivity.EXTRA_ARGS_POSITION, position);
                 startActivity(intent);
-            } catch (Exception e) {
+            } catch (Exception e) { // Putting too much data into the Bundle
+                // TODO: Find a better way to pass data between the activities - possibly a key to
+                // access a HashMap or a unique value of a singleton Data Repository of some sort.
                 intent.setAction(SingleMediaActivity.ACTION_OPEN_ALBUM_LAZY);
-                intent.putExtra("media", media.get(position));
+                intent.putExtra(SingleMediaActivity.EXTRA_ARGS_MEDIA, media.get(position));
                 startActivity(intent);
             }
 

--- a/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
@@ -2,6 +2,7 @@ package org.horaapps.leafpic.activities;
 
 import android.animation.ArgbEvaluator;
 import android.animation.ValueAnimator;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
@@ -11,9 +12,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Parcelable;
 import android.provider.Settings;
 import android.support.annotation.CallSuper;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AlertDialog;
@@ -53,6 +57,7 @@ import org.horaapps.leafpic.data.provider.CPHelper;
 import org.horaapps.leafpic.data.sort.MediaComparators;
 import org.horaapps.leafpic.data.sort.SortingMode;
 import org.horaapps.leafpic.data.sort.SortingOrder;
+import org.horaapps.leafpic.fragments.BaseMediaFragment;
 import org.horaapps.leafpic.fragments.ImageFragment;
 import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.AnimationUtils;
@@ -67,6 +72,7 @@ import org.horaapps.liz.ColorPalette;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -79,33 +85,47 @@ import io.reactivex.schedulers.Schedulers;
  * Created by dnld on 18/02/16.
  */
 @SuppressWarnings("ResourceAsColor")
-public class SingleMediaActivity extends SharedMediaActivity {
+public class SingleMediaActivity extends SharedMediaActivity implements BaseMediaFragment.MediaTapListener {
 
     private static final String TAG = SingleMediaActivity.class.getSimpleName();
 
     private static final int SLIDE_SHOW_INTERVAL = 5000;
     private static final String ISLOCKED_ARG = "isLocked";
+
     public static final String ACTION_OPEN_ALBUM = "org.horaapps.leafpic.intent.VIEW_ALBUM";
     public static final String ACTION_OPEN_ALBUM_LAZY = "org.horaapps.leafpic.intent.VIEW_ALBUM_LAZY";
     private static final String ACTION_REVIEW = "com.android.camera.action.REVIEW";
 
+    public static final String EXTRA_ARGS_ALBUM = "args_album";
+    public static final String EXTRA_ARGS_MEDIA = "args_media";
+    public static final String EXTRA_ARGS_POSITION = "args_position";
 
-    @BindView(R.id.photos_pager)
-    HackyViewPager mViewPager;
-
-    @BindView(R.id.PhotoPager_Layout)
-    RelativeLayout activityBackground;
-    @BindView(R.id.toolbar)
-    Toolbar toolbar;
+    @BindView(R.id.photos_pager) HackyViewPager mViewPager;
+    @BindView(R.id.PhotoPager_Layout) RelativeLayout activityBackground;
+    @BindView(R.id.toolbar) Toolbar toolbar;
 
     private boolean fullScreenMode, customUri = false;
-    int position;
+    private int position;
 
     private Album album;
     private ArrayList<Media> media;
     private MediaPagerAdapter adapter;
     private boolean isSlideShowOn = false;
 
+    private boolean useImageMenu;
+
+    public static void startActivity(@NonNull Context context,
+                                     @Nullable Parcelable album,
+                                     @Nullable Serializable media,
+                                     int position) {
+
+        Intent intent = new Intent(context, SingleMediaActivity.class);
+        intent.putExtra(EXTRA_ARGS_ALBUM, album);
+        intent.setAction(ACTION_OPEN_ALBUM);
+        intent.putExtra(EXTRA_ARGS_MEDIA, media);
+        intent.putExtra(EXTRA_ARGS_POSITION, position);
+        context.startActivity(intent);
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -146,15 +166,15 @@ public class SingleMediaActivity extends SharedMediaActivity {
     }
 
     private void loadAlbum(Intent intent) {
-        album = intent.getParcelableExtra("album");
-        position = intent.getIntExtra("position", 0);
-        media = intent.getParcelableArrayListExtra("media");
+        album = intent.getParcelableExtra(EXTRA_ARGS_ALBUM);
+        position = intent.getIntExtra(EXTRA_ARGS_POSITION, 0);
+        media = intent.getParcelableArrayListExtra(EXTRA_ARGS_MEDIA);
     }
 
     private void loadAlbumsLazy(Intent intent) {
-        album = intent.getParcelableExtra("album");
-        //position = intent.getIntExtra("position", 0);
-        Media m = intent.getParcelableExtra("media");
+        album = intent.getParcelableExtra(EXTRA_ARGS_ALBUM);
+        //position = intent.getIntExtra(EXTRA_ARGS_POSITION, 0);
+        Media m = intent.getParcelableExtra(EXTRA_ARGS_MEDIA);
         media = new ArrayList<>();
         media.add(m);
         position = 0;
@@ -243,6 +263,9 @@ public class SingleMediaActivity extends SharedMediaActivity {
 
         mViewPager.setAdapter(adapter);
         mViewPager.setCurrentItem(position);
+
+        useImageMenu = isCurrentMediaImage();
+
         mViewPager.setPageTransformer(true, AnimationUtils.getPageTransformer(new DepthPageTransformer()));
 
         mViewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
@@ -253,8 +276,10 @@ public class SingleMediaActivity extends SharedMediaActivity {
             @Override
             public void onPageSelected(int position) {
                 SingleMediaActivity.this.position = position;
-
                 updatePageTitle(position);
+
+                // Invalidate the options menu only when we aren't using the correct menu
+                if (isCurrentMediaImage() == useImageMenu) return;
                 supportInvalidateOptionsMenu();
             }
 
@@ -270,6 +295,12 @@ public class SingleMediaActivity extends SharedMediaActivity {
         }
     }
 
+    // TODO: Figure out how we should classify Images and GIFs
+    // This should work temporarily
+    private boolean isCurrentMediaImage() {
+        return getCurrentMedia().isImage() && !getCurrentMedia().isGif();
+    }
+
     Handler handler = new Handler();
     Runnable slideShowRunnable = new Runnable() {
         @Override
@@ -283,6 +314,11 @@ public class SingleMediaActivity extends SharedMediaActivity {
             }
         }
     };
+
+    @Override
+    public void onViewTapped() {
+        toggleSystemUI();
+    }
 
     @CallSuper
     public void updateUiElements() {
@@ -374,7 +410,9 @@ public class SingleMediaActivity extends SharedMediaActivity {
     @Override
     public boolean onPrepareOptionsMenu(final Menu menu) {
         if (!isSlideShowOn) {
-            menu.setGroupVisible(R.id.only_photos_options, !getCurrentMedia().isVideo());
+            boolean isImage = isCurrentMediaImage();
+            useImageMenu = isImage;
+            menu.setGroupVisible(R.id.only_photos_options, isImage);
 
             if (customUri) {
                 menu.setGroupVisible(R.id.on_internal_storage, false);
@@ -383,7 +421,6 @@ public class SingleMediaActivity extends SharedMediaActivity {
             }
         }
         return super.onPrepareOptionsMenu(menu);
-
     }
 
     @Override
@@ -446,20 +483,28 @@ public class SingleMediaActivity extends SharedMediaActivity {
 
     }
 
+    private void rotateImage(int rotationDegree) {
+        Fragment mediaFragment = adapter.getRegisteredFragment(position);
+        if (!(mediaFragment instanceof ImageFragment))
+            throw new RuntimeException("Trying to rotate a wrong media type!");
+
+        ((ImageFragment) mediaFragment).rotatePicture(rotationDegree);
+    }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
 
             case R.id.rotate_180:
-                ((ImageFragment) adapter.getRegisteredFragment(position)).rotatePicture(180);
+                rotateImage(180);
                 break;
 
             case R.id.rotate_right_90:
-                ((ImageFragment) adapter.getRegisteredFragment(position)).rotatePicture(90);
+                rotateImage(90);
                 break;
 
             case R.id.rotate_left_90:
-                ((ImageFragment) adapter.getRegisteredFragment(position)).rotatePicture(-90);
+                rotateImage(-90);
                 break;
 
 
@@ -691,10 +736,6 @@ public class SingleMediaActivity extends SharedMediaActivity {
                 } else handler.removeCallbacks(slideShowRunnable);
                 supportInvalidateOptionsMenu();
 
-            default:
-                // If we got here, the user's action was not recognized.
-                // Invoke the superclass to handle it.
-                //return super.onOptionsItemSelected(item);
         }
         return super.onOptionsItemSelected(item);
     }
@@ -761,16 +802,15 @@ public class SingleMediaActivity extends SharedMediaActivity {
     }
 
     public void toggleSystemUI() {
-        if (fullScreenMode)
-            showSystemUI();
+        if (fullScreenMode) showSystemUI();
         else hideSystemUI();
     }
 
     private void hideSystemUI() {
         runOnUiThread(new Runnable() {
             public void run() {
-                    toolbar.animate().translationY(-toolbar.getHeight()).setInterpolator(new AccelerateInterpolator())
-                            .setDuration(200).start();
+                toolbar.animate().translationY(-toolbar.getHeight()).setInterpolator(new AccelerateInterpolator())
+                        .setDuration(200).start();
 
                 getWindow().getDecorView().setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
                     @Override
@@ -806,7 +846,7 @@ public class SingleMediaActivity extends SharedMediaActivity {
         runOnUiThread(new Runnable() {
             public void run() {
                 toolbar.animate().translationY(Measure.getStatusBarHeight(getResources())).setInterpolator(new DecelerateInterpolator())
-                            .setDuration(240).start();
+                        .setDuration(240).start();
 
                 getWindow().getDecorView().setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE

--- a/app/src/main/java/org/horaapps/leafpic/adapters/MediaPagerAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/MediaPagerAdapter.java
@@ -1,5 +1,6 @@
 package org.horaapps.leafpic.adapters;
 
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -29,20 +30,24 @@ public class MediaPagerAdapter extends FragmentStatePagerAdapter {
         this.media = media;
     }
 
-    @Override public Fragment getItem(int pos) {
+    @Override
+    public Fragment getItem(int pos) {
         Media media = this.media.get(pos);
         if (media.isVideo()) return VideoFragment.newInstance(media);
         if (media.isGif()) return GifFragment.newInstance(media);
         else return ImageFragment.newInstance(media);
     }
 
-    @Override public Object instantiateItem(ViewGroup container, int position) {
+    @NonNull
+    @Override
+    public Object instantiateItem(ViewGroup container, int position) {
         Fragment fragment = (Fragment) super.instantiateItem(container, position);
         registeredFragments.put(position, fragment);
         return fragment;
     }
 
-    @Override public void destroyItem(ViewGroup container, int position, Object object) {
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
         registeredFragments.remove(position);
         super.destroyItem(container, position, object);
     }
@@ -56,11 +61,13 @@ public class MediaPagerAdapter extends FragmentStatePagerAdapter {
         notifyDataSetChanged();
     }
 
-    @Override public int getItemPosition(Object object) {
+    @Override
+    public int getItemPosition(@NonNull Object object) {
         return PagerAdapter.POSITION_NONE;
     }
 
-    @Override public int getCount() {
+    @Override
+    public int getCount() {
         return media.size();
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/BaseMediaFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/BaseMediaFragment.java
@@ -1,0 +1,73 @@
+package org.horaapps.leafpic.fragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import org.horaapps.leafpic.data.Media;
+import org.horaapps.liz.ThemeHelper;
+import org.horaapps.liz.ThemedFragment;
+
+/**
+ * A Base Fragment for showing Media.
+ */
+public abstract class BaseMediaFragment extends ThemedFragment {
+
+    private static final String ARGS_MEDIA = "args_media";
+
+    protected Media media;
+    private MediaTapListener mediaTapListener;
+
+    @NonNull
+    protected static <T extends BaseMediaFragment> T newInstance(@NonNull T mediaFragment,
+                                                                 @NonNull Media media) {
+
+        Bundle args = new Bundle();
+        args.putParcelable(ARGS_MEDIA, media);
+        mediaFragment.setArguments(args);
+        return mediaFragment;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof MediaTapListener) mediaTapListener = (MediaTapListener) context;
+    }
+
+    private void fetchArgs() {
+        Bundle args = getArguments();
+        if (args == null) throw new RuntimeException("Must pass arguments to Media Fragments!");
+        media = getArguments().getParcelable(ARGS_MEDIA);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        fetchArgs();
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        // Default implementation
+    }
+
+    protected void setTapListener(@NonNull View view) {
+        view.setOnClickListener(v -> onTapped());
+    }
+
+    private void onTapped() {
+        mediaTapListener.onViewTapped();
+    }
+
+    /**
+     * Interface for listeners to react on Media Clicks.
+     */
+    public interface MediaTapListener {
+
+        /**
+         * Called when user taps on the Media view.
+         */
+        void onViewTapped();
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/fragments/GifFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/GifFragment.java
@@ -1,44 +1,33 @@
 package org.horaapps.leafpic.fragments;
 
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import org.horaapps.leafpic.activities.SingleMediaActivity;
 import org.horaapps.leafpic.data.Media;
 
 import pl.droidsonroids.gif.GifImageView;
 
 /**
- * Created by dnld on 18/02/16.
+ * Media Fragment for showing an Image (static)
  */
-public class GifFragment extends Fragment {
+public class GifFragment extends BaseMediaFragment {
 
-    private Media gif;
-
-    public static GifFragment newInstance(Media media) {
-        GifFragment gifFragment = new GifFragment();
-
-        Bundle args = new Bundle();
-        args.putParcelable("gif", media);
-        gifFragment.setArguments(args);
-
-        return gifFragment;
-
+    @NonNull
+    public static GifFragment newInstance(@NonNull Media media) {
+        return BaseMediaFragment.newInstance(new GifFragment(), media);
     }
 
-    @Override public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        gif = getArguments().getParcelable("gif");
-    }
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             ViewGroup container,
+                             Bundle savedInstanceState) {
 
-
-    @Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        GifImageView photoView = new GifImageView(container.getContext());
-        photoView.setImageURI(gif.getUri());
-        photoView.setOnClickListener(view -> ((SingleMediaActivity) getActivity()).toggleSystemUI());
+        GifImageView photoView = new GifImageView(getContext());
+        photoView.setImageURI(media.getUri());
+        setTapListener(photoView);
         return photoView;
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/ImageFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/ImageFragment.java
@@ -1,8 +1,9 @@
 package org.horaapps.leafpic.fragments;
 
+import android.net.Uri;
 import android.os.Bundle;
-import android.support.v4.app.Fragment;
-import android.util.Log;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,80 +12,53 @@ import com.davemorrissey.labs.subscaleview.ImageSource;
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView;
 
 import org.horaapps.leafpic.R;
-import org.horaapps.leafpic.activities.SingleMediaActivity;
 import org.horaapps.leafpic.data.Media;
 import org.horaapps.leafpic.util.BitmapUtils;
 
-import java.io.InputStream;
-
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import butterknife.Unbinder;
-
 
 /**
- * Created by dnld on 18/02/16.
+ * A Media Fragment for showing an Image (static)
  */
+public class ImageFragment extends BaseMediaFragment {
 
-@SuppressWarnings("ResourceType")
-public class ImageFragment extends Fragment {
+    @BindView(R.id.subsampling_view) SubsamplingScaleImageView imageView;
 
-    View view;
-    private Media img;
-    private Unbinder unbinder;
-
-    @BindView(R.id.subsampling_view)
-    SubsamplingScaleImageView subsampling;
-
-    public static ImageFragment newInstance(Media media) {
-        ImageFragment imageFragment = new ImageFragment();
-        Bundle args = new Bundle();
-        args.putParcelable("image", media);
-        imageFragment.setArguments(args);
-        return imageFragment;
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        img = getArguments().getParcelable("image");
+    @NonNull
+    public static ImageFragment newInstance(@NonNull Media media) {
+        return BaseMediaFragment.newInstance(new ImageFragment(), media);
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        view = inflater.inflate(R.layout.fragment_photo, container, false);
-        unbinder = ButterKnife.bind(this, view);
-
-        int orientation = BitmapUtils.getOrientation(img.getUri(),this.getContext());
-        subsampling.setOrientation(orientation);
-        subsampling.setImage(ImageSource.uri(img.getUri()));
-        subsampling.setOnClickListener(view -> ((SingleMediaActivity) getActivity()).toggleSystemUI());
-
-        return view;
+        View rootView = inflater.inflate(R.layout.fragment_photo, container, false);
+        ButterKnife.bind(this, rootView);
+        return rootView;
     }
 
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        Uri mediaUri = media.getUri();
+        imageView.setOrientation(BitmapUtils.getOrientation(mediaUri, getContext()));
+        imageView.setImage(ImageSource.uri(mediaUri));
+        setTapListener(imageView);
+    }
 
     @Override
     public void onDestroyView() {
+        imageView.recycle();
         super.onDestroyView();
-        subsampling.recycle();
-        unbinder.unbind();
     }
 
-    /* private void rotateLoop() { //april fools
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                photoView.setRotationBy(1);
-                rotateLoop();
-            }
-        }, 5);
-    }*/
-
-    public void rotatePicture(int rotation) {
-        if (rotation == -90 && subsampling.getOrientation() == 0)
-            subsampling.setOrientation(SubsamplingScaleImageView.ORIENTATION_270);
-        else
-            subsampling.setOrientation((subsampling.getOrientation() + rotation) % 360);
+    /**
+     * Rotate the currently displaying media image.
+     *
+     * @param rotationInDegrees The rotation in degrees
+     */
+    public void rotatePicture(int rotationInDegrees) {
+        if (rotationInDegrees == -90 && imageView.getOrientation() == 0) imageView.setOrientation(SubsamplingScaleImageView.ORIENTATION_270);
+        else imageView.setOrientation(Math.abs(imageView.getOrientation() + rotationInDegrees) % 360);
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/VideoFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/VideoFragment.java
@@ -3,6 +3,8 @@ package org.horaapps.leafpic.fragments;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,72 +14,59 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.request.RequestOptions;
 
-import org.horaapps.leafpic.activities.SingleMediaActivity;
+import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.data.Media;
 import org.horaapps.leafpic.data.StorageHelper;
 import org.horaapps.liz.ThemeHelper;
-import org.horaapps.liz.ThemedFragment;
 import org.horaapps.liz.ui.ThemedIcon;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
 /**
- * Created by dnld on 18/02/16.
+ * A Media Fragment for showing a Video Preview.
  */
+public class VideoFragment extends BaseMediaFragment {
 
-public class VideoFragment extends ThemedFragment {
+    @BindView(R.id.media_view) ImageView previewView;
+    @BindView(R.id.video_play_icon) ThemedIcon playVideoIcon;
 
-    ThemedIcon videoInd;
+    @NonNull
+    public static VideoFragment newInstance(@NonNull Media media) {
+        return BaseMediaFragment.newInstance(new VideoFragment(), media);
+    }
 
-    private Media video;
-	
-	public static VideoFragment newInstance(Media media) {
-		VideoFragment videoFragment = new VideoFragment();
-		
-		Bundle args = new Bundle();
-		args.putParcelable("video", media);
-		videoFragment.setArguments(args);
-		
-		return videoFragment;
-	}
-	
-	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		video = getArguments().getParcelable("video");
-	}
-	
-	
-	@Override
-	public View onCreateView(LayoutInflater inflater, ViewGroup container,
-	                         Bundle savedInstanceState) {
-		
-		
-		View view =
-				inflater.inflate(org.horaapps.leafpic.R.layout.fragment_video, container, false);
-		
-		ImageView picture = view.findViewById(org.horaapps.leafpic.R.id.media_view);
-		videoInd = view.findViewById(org.horaapps.leafpic.R.id.icon);
-		videoInd.setOnClickListener(v -> {
-			Uri uri = StorageHelper.getUriForFile(getContext(), video.getFile());
-			Intent intent = new Intent(Intent.ACTION_VIEW).setDataAndType(uri, video.getMimeType());
-			intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-			startActivity(intent);
-		});
-		
-		
-		RequestOptions options =
-				new RequestOptions().signature(video.getSignature()).centerCrop()
-						.diskCacheStrategy(
-						DiskCacheStrategy.AUTOMATIC);
-		
-		
-		Glide.with(getContext()).load(video.getUri()).apply(options).into(picture);
-		
-		picture.setOnClickListener(v -> ((SingleMediaActivity) getActivity()).toggleSystemUI());
-		return view;
-	}
-	
-	@Override
-	public void refreshTheme(ThemeHelper themeHelper) {
-		videoInd.refreshTheme(themeHelper);
-	}
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View rootView = inflater.inflate(R.layout.fragment_video, container, false);
+        ButterKnife.bind(this, rootView);
+        return rootView;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        playVideoIcon.setOnClickListener(v -> {
+            Uri uri = StorageHelper.getUriForFile(getContext(), media.getFile());
+            Intent intent = new Intent(Intent.ACTION_VIEW).setDataAndType(uri, media.getMimeType());
+            intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            startActivity(intent);
+        });
+
+        // TODO: See where we can move this. Seems like boilerplate code that belongs in
+        // a utility class or Builder of some sort.
+        RequestOptions options =
+                new RequestOptions().signature(media.getSignature()).centerCrop()
+                        .diskCacheStrategy(
+                                DiskCacheStrategy.AUTOMATIC);
+
+        Glide.with(getContext()).load(media.getUri()).apply(options).into(previewView);
+        setTapListener(previewView);
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper themeHelper) {
+        playVideoIcon.refreshTheme(themeHelper);
+    }
 }

--- a/app/src/main/res/layout/fragment_video.xml
+++ b/app/src/main/res/layout/fragment_video.xml
@@ -1,24 +1,22 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-     xmlns:app="http://schemas.android.com/apk/res-auto"
-     android:layout_width="match_parent"
-     android:layout_height="match_parent"
-     android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
     <org.horaapps.liz.ui.ThemedIcon
-        android:id="@+id/icon"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
-        android:layout_gravity="center_vertical|center_horizontal"
+        android:id="@+id/video_play_icon"
+        android:layout_width="@dimen/video_play_icon_size"
+        android:layout_height="@dimen/video_play_icon_size"
+        android:layout_gravity="center"
+        android:alpha="0.7"
         android:elevation="10dp"
-        android:visibility="visible"
         app:iiv_color="@color/md_white_1000"
-        app:iiv_icon="gmd-play-circle-filled"
-        android:alpha="0.7"/>
+        app:iiv_icon="@string/icon_play" />
+
     <ImageView
         android:id="@+id/media_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@drawable/ripple"
-        android:clickable="true"
-        />
+        android:background="@drawable/ripple" />
+
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -39,4 +39,7 @@
     <dimen name="about_link_icon_right_margin">24dp</dimen>
     <dimen name="about_link_padding">8dp</dimen>
 
+    <!-- Media -->
+    <dimen name="video_play_icon_size">50dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/icons.xml
+++ b/app/src/main/res/values/icons.xml
@@ -19,4 +19,7 @@
     <string name="icon_license">gmd-insert-drive-file</string>
     <string name="icon_changelog">gmd-new-releases</string>
 
+    <!-- Media -->
+    <string name="icon_play">gmd-play-circle-filled</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,7 +119,7 @@ and this could make the media inaccessible from other apps. Use the exclude opti
     <string name="send_to">Send to</string>
     <string name="search_menu">search</string>
     <string name="full_resolution">Full resolution</string>
-    <string name="of">%d of %d</string>
+    <string name="of">%1$d of %2$d</string>
 
     <!-- PALETTE-->
     <string name="palette">Palette</string>


### PR DESCRIPTION
Issue:
- When the user tries to rotate a GIF, the app crashes
- When the user taps on Media to hide / show SystemUI,
  the app crashes

Root Cause:
- Rotating Gifs is not a supported feature
- When this action is tried, the code fetches the current fragment
  and casts it into an ImageFragment, which it's not
- We call toggleSystemUI on the Activity, which can be null.

Fixes:
- Added a state boolean to maintain if we are showing the Image
  Menu (rotate, use as) or not.
- We now only invalidate the menu on ViewPager swipe if the new
  media needs a different Menu (image - video - gif)
- Added BaseMediaFragment to hold boilerplate code of getting the
  Media, and toggling System UI.
- Removed all Activity dependencies in Media Fragments.
- Minor cleanup and fixes.