### PR TITLE
Fix image orientation issue, Upgrade dependencies, Gradle 3.10 for AS 3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
     //exifInterface
     implementation "com.android.support:exifinterface:$supportVersion"
+
     // google & support
     implementation "com.android.support:appcompat-v7:$supportVersion"
     implementation "com.android.support:cardview-v7:$supportVersion"
@@ -118,7 +119,7 @@ dependencies {
     implementation 'com.github.jetradarmobile:desertplaceholder:1.1.1'
     implementation 'de.hdodenhof:circleimageview:2.2.0'
     implementation 'com.yalantis:ucrop:1.5.0'
-    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.8.0'
+    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'
     implementation 'jp.wasabeef:recyclerview-animators:2.2.7'
     implementation 'com.github.HoraApps:Liz:-SNAPSHOT'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,10 @@ buildscript {
         maven {
             url "https://maven.google.com"
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-alpha08'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,7 +17,7 @@ buildscript {
 }
 
 project.ext {
-    supportVersion = "27.0.2"
+    supportVersion = "27.1.0"
     sdkVersion = 27
 }
 


### PR DESCRIPTION
Fix image orientation issue, Upgrade dependencies, Gradle 3.10 for AS 3.1

- Fixed an issue where the ImageFragment would not show the picture in
  correct rotation when it had Exif data. This seems to be fixed in
  Subsampling-Image 3.10
- Updated support libraries to 27.1.0
- Updated Gradle to stable release for AS 3.1