### PR TITLE
Fixed a selection count regression

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/MainActivity.java
@@ -205,12 +205,17 @@ public class MainActivity extends SharedMediaActivity implements
     public void changedEditMode(boolean editMode, int selected, int total, @javax.annotation.Nullable View.OnClickListener listener, @javax.annotation.Nullable String title) {
         if (editMode) {
             updateToolbar(
-                    String.format(Locale.ENGLISH, "%d/%d", selected, total),
+                    getString(R.string.toolbar_selection_count, selected, total),
                     GoogleMaterial.Icon.gmd_check, listener);
         } else {
             if (albumsMode) resetToolbar();
             else updateToolbar(title, GoogleMaterial.Icon.gmd_arrow_back, v -> goBackToAlbums());
         }
+    }
+
+    @Override
+    public void onItemsSelected(int count, int total) {
+        toolbar.setTitle(getString(R.string.toolbar_selection_count, count, total));
     }
 
     @Override

--- a/app/src/main/java/org/horaapps/leafpic/adapters/AlbumsAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/AlbumsAdapter.java
@@ -235,6 +235,8 @@ public class AlbumsAdapter extends ThemedAdapter<AlbumsAdapter.ViewHolder> {
 
     private void notifySelected(boolean increase) {
         selectedCount += increase ? 1 : -1;
+        actionsListener.onSelectionCountChanged(selectedCount, getItemCount());
+
         if (selectedCount == 0 && isSelecting) stopSelection();
         else if (selectedCount > 0 && !isSelecting) startSelection();
     }

--- a/app/src/main/java/org/horaapps/leafpic/adapters/MediaAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/MediaAdapter.java
@@ -147,6 +147,7 @@ public class MediaAdapter extends ThemedAdapter<MediaAdapter.ViewHolder> {
 
     private void notifySelected(boolean increase) {
         selectedCount += increase ? 1 : -1;
+        actionsListener.onSelectionCountChanged(selectedCount, getItemCount());
 
         if (selectedCount == 0 && isSelecting) stopSelection();
         else if (selectedCount > 0 && !isSelecting) startSelection();

--- a/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
@@ -512,6 +512,10 @@ public class AlbumsFragment extends BaseFragment {
         getActivity().invalidateOptionsMenu();
     }
 
+    @Override
+    public void onSelectionCountChanged(int selectionCount, int totalCount) {
+        getEditModeListener().onItemsSelected(selectionCount, totalCount);
+    }
 
     @Override
     public void refreshTheme(ThemeHelper t) {

--- a/app/src/main/java/org/horaapps/leafpic/fragments/EditModeListener.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/EditModeListener.java
@@ -10,4 +10,12 @@ import javax.annotation.Nullable;
 
 public interface EditModeListener {
     void changedEditMode(boolean editMode, int selected, int total, @Nullable View.OnClickListener listener, @Nullable String title);
+
+    /**
+     * Propagate the selected item count to listeners.
+     *
+     * @param count The number of items selected.
+     * @param total The total number of items.
+     */
+    void onItemsSelected(int count, int total);
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
@@ -680,6 +680,11 @@ public class RvMediaFragment extends BaseFragment {
     }
 
     @Override
+    public void onSelectionCountChanged(int selectionCount, int totalCount) {
+        getEditModeListener().onItemsSelected(selectionCount, totalCount);
+    }
+
+    @Override
     public boolean clearSelected() {
         return adapter.clearSelected();
     }

--- a/app/src/main/java/org/horaapps/leafpic/items/ActionsListener.java
+++ b/app/src/main/java/org/horaapps/leafpic/items/ActionsListener.java
@@ -23,4 +23,12 @@ public interface ActionsListener {
      * @param selectMode Whether we want to be in select mode or not.
      */
     void onSelectMode(boolean selectMode);
+
+    /**
+     * Used to notify listeners about selection counts.
+     *
+     * @param selectionCount The number of selected items
+     * @param totalCount     The number of total items
+     */
+    void onSelectionCountChanged(int selectionCount, int totalCount);
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,4 +413,7 @@ and this could make the media inaccessible from other apps. Use the exclude opti
     <string name="waring_share_multiple_file_types">There may be problems sharing multiple file types</string>
     <string name="creators">Creators</string>
     <string name="major_contributors">Major contributors</string>
+
+    <string name="toolbar_selection_count" translatable="false">%1$d of %2$d</string>
+
 </resources>


### PR DESCRIPTION
Issue:
- When items are long pressed to enter selection mode and
  then select multiple, the count in Toolbar is not updated.

Root cause:
- Due to PR #527, we did not notify the Edit Mode listener
  more than once, only when Edit Mode is entered or exited.
- Changing the toolbar count was a feature of Edit Mode listener.

Fixes:
- Added method onSelectionCountChanged to ActionsListener for
  notifying fragments about selection counts.
- Added method onItemsSelected to EditModeListener to notify
  the Edit Mode listener about item selections.
- Updated the Toolbar title when items are selected.
- Changed title style from "1/10" to "1 of 10" for readability.

Copy of #536 targeted at dev.