### PR TITLE
Fixing issue where Resolution was not visible.

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/data/Media.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/Media.java
@@ -148,8 +148,7 @@ public class Media implements CursorHandler, Parcelable {
         return orientation;
     }
 
-    //<editor-fold desc="Exif & More">
-// TODO remove from here!
+// git staTODO remove from here!
     @Deprecated
     public Bitmap getBitmap(){
         BitmapFactory.Options bmOptions = new BitmapFactory.Options();
@@ -157,6 +156,7 @@ public class Media implements CursorHandler, Parcelable {
         bitmap = Bitmap.createScaledBitmap(bitmap,bitmap.getWidth(),bitmap.getHeight(),true);
         return bitmap;
     }
+
     @Deprecated
     public GeoLocation getGeoLocation()  {
         return /*metadata != null ? metadata.getLocation() :*/ null;
@@ -167,24 +167,22 @@ public class Media implements CursorHandler, Parcelable {
         this.orientation = orientation;
         // TODO: 28/08/16  find a better way
         // TODO update also content provider
-        new Thread(new Runnable() {
-            public void run() {
-                int exifOrientation = -1;
-                try {
-                    ExifInterface  exif = new ExifInterface(path);
-                    switch (orientation) {
-                        case 90: exifOrientation = ExifInterface.ORIENTATION_ROTATE_90; break;
-                        case 180: exifOrientation = ExifInterface.ORIENTATION_ROTATE_180; break;
-                        case 270: exifOrientation = ExifInterface.ORIENTATION_ROTATE_270; break;
-                        case 0: exifOrientation = ExifInterface.ORIENTATION_NORMAL; break;
-                    }
-                    if (exifOrientation != -1) {
-                        exif.setAttribute(ExifInterface.TAG_ORIENTATION, String.valueOf(exifOrientation));
-                        exif.saveAttributes();
-                    }
+        new Thread(() -> {
+            int exifOrientation = -1;
+            try {
+                ExifInterface  exif = new ExifInterface(path);
+                switch (orientation) {
+                    case 90: exifOrientation = ExifInterface.ORIENTATION_ROTATE_90; break;
+                    case 180: exifOrientation = ExifInterface.ORIENTATION_ROTATE_180; break;
+                    case 270: exifOrientation = ExifInterface.ORIENTATION_ROTATE_270; break;
+                    case 0: exifOrientation = ExifInterface.ORIENTATION_NORMAL; break;
                 }
-                catch (IOException ignored) {  }
+                if (exifOrientation != -1) {
+                    exif.setAttribute(ExifInterface.TAG_ORIENTATION, String.valueOf(exifOrientation));
+                    exif.saveAttributes();
+                }
             }
+            catch (IOException ignored) {  }
         }).start();
         return true;
     }
@@ -218,8 +216,6 @@ public class Media implements CursorHandler, Parcelable {
         }
         return false;
     }
-
-    //</editor-fold>
 
     public File getFile() {
         if (path != null) {

--- a/app/src/main/java/org/horaapps/leafpic/data/Media.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/Media.java
@@ -148,7 +148,7 @@ public class Media implements CursorHandler, Parcelable {
         return orientation;
     }
 
-// git staTODO remove from here!
+    //TODO remove from here!
     @Deprecated
     public Bitmap getBitmap(){
         BitmapFactory.Options bmOptions = new BitmapFactory.Options();

--- a/app/src/main/java/org/horaapps/leafpic/data/metadata/MetaDataItem.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/metadata/MetaDataItem.java
@@ -1,5 +1,6 @@
 package org.horaapps.leafpic.data.metadata;
 
+import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.support.annotation.NonNull;
 
@@ -12,6 +13,8 @@ import com.drew.metadata.exif.ExifIFD0Directory;
 import com.drew.metadata.exif.ExifSubIFDDirectory;
 import com.drew.metadata.exif.GpsDirectory;
 import com.drew.metadata.xmp.XmpDirectory;
+
+import org.horaapps.leafpic.data.Media;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,8 +40,8 @@ class MetaDataItem {
     private GeoLocation location = null;
     private int orientation = -1, height = -1, width = -1;
 
-    static MetaDataItem getMetadata(@NonNull InputStream in) throws ImageProcessingException, IOException {
-        return new MetaDataItem(in, true);
+    static MetaDataItem getMetadata(@NonNull InputStream in, Media media) throws ImageProcessingException, IOException {
+        return new MetaDataItem(in, true, media);
     }
 
     private MetaDataItem(InputStream in) throws ImageProcessingException, IOException {
@@ -68,14 +71,14 @@ class MetaDataItem {
         if(d != null) location  = d.getGeoLocation();
     }
 
-    private MetaDataItem(InputStream in, boolean resolution) throws ImageProcessingException, IOException {
+    private MetaDataItem(InputStream in, boolean resolution, Media media) throws ImageProcessingException, IOException {
         this(in);
         if(resolution) {
             BitmapFactory.Options options = new BitmapFactory.Options();
             options.inJustDecodeBounds = true;
-            BitmapFactory.decodeStream(in, null, options);
-            width = options.outWidth;
-            height = options.outHeight;
+            Bitmap bitmap = BitmapFactory.decodeFile(media.getPath(), options);
+            width = bitmap.getWidth();
+            height = bitmap.getHeight();
         }
     }
 
@@ -100,10 +103,10 @@ class MetaDataItem {
 
 
     public String getResolution() {
-        if (width != -1 && -1 != height)
-            return String.format(Locale.getDefault(),"%dx%d", width, height);
-        else return "¿x?";
+        return (width != -1 && height != -1) ?
+                String.format(Locale.getDefault(),"%dx%d", width, height) : "¿x?";
     }
+
     public int getOrientation() {
         return orientation;
     }

--- a/app/src/main/java/org/horaapps/leafpic/data/metadata/MetaDataItem.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/metadata/MetaDataItem.java
@@ -76,8 +76,10 @@ class MetaDataItem {
         if(resolution) {
             BitmapFactory.Options options = new BitmapFactory.Options();
             Bitmap bitmap = BitmapFactory.decodeFile(media.getPath(), options);
+            bitmap = Bitmap.createScaledBitmap(bitmap,bitmap.getWidth(),bitmap.getHeight(),true);
             width = bitmap.getWidth();
             height = bitmap.getHeight();
+            options.inJustDecodeBounds = true;
         }
     }
 

--- a/app/src/main/java/org/horaapps/leafpic/data/metadata/MetaDataItem.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/metadata/MetaDataItem.java
@@ -75,7 +75,6 @@ class MetaDataItem {
         this(in);
         if(resolution) {
             BitmapFactory.Options options = new BitmapFactory.Options();
-            options.inJustDecodeBounds = true;
             Bitmap bitmap = BitmapFactory.decodeFile(media.getPath(), options);
             width = bitmap.getWidth();
             height = bitmap.getHeight();

--- a/app/src/main/java/org/horaapps/leafpic/data/metadata/MetadataHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/metadata/MetadataHelper.java
@@ -25,13 +25,15 @@ public class MetadataHelper {
         MediaDetailsMap<String, String> details = new MediaDetailsMap<>();
         details.put(context.getString(R.string.path), m.getDisplayPath());
         details.put(context.getString(R.string.type), m.getMimeType());
-        if(m.getSize() != -1)
+        if(m.getSize() != -1) {
             details.put(context.getString(R.string.size), StringUtils.humanReadableByteCount(m.getSize(), true));
-        // TODO should i add this always?
-        details.put(context.getString(R.string.orientation), m.getOrientation() + "");
+        }
+        // TODO find a better way to list orientation. A number isn't very useful from a user perspective
+        // details.put(context.getString(R.string.orientation), m.getOrientation() + "");
         try {
-            MetaDataItem metadata = MetaDataItem.getMetadata(context.getContentResolver().openInputStream(m.getUri()));
-            details.put(context.getString(R.string.resolution), metadata.getResolution());
+            MetaDataItem metadata = MetaDataItem.getMetadata(context.getContentResolver().openInputStream(m.getUri()), m);
+            String res = metadata.getResolution();
+            details.put(context.getString(R.string.resolution), res);
             details.put(context.getString(R.string.date), SimpleDateFormat.getDateTimeInstance().format(new Date(m.getDateModified())));
             Date dateOriginal = metadata.getDateOriginal();
             if (dateOriginal != null )
@@ -53,7 +55,7 @@ public class MetadataHelper {
     }
 
     public MediaDetailsMap<String, String> getAllDetails(Context context, Media media) {
-        MediaDetailsMap<String, String> data = new MediaDetailsMap<String, String>();
+        MediaDetailsMap<String, String> data = new MediaDetailsMap<>();
         try {
             Metadata metadata = ImageMetadataReader.readMetadata(context.getContentResolver().openInputStream(media.getUri()));
             for(Directory directory : metadata.getDirectories()) {


### PR DESCRIPTION
This addresses an issue mentioned **[here](https://waffle.io/HoraApps/LeafPic/cards/5aa2138cac5649001dfc4210)**

Uses the same method of getting the bitMap height and width that `Media.java` used, but avoids using the explicit `getResolution` method. This is because it is annotated as Deprecated for some reason and should probably be removed or handled in some other way if this is the case. This was handled by passing Media into `MetaDataItem`.

Adding Dagger2 to the project at some point may help simplify dependency injection for the project in cases like this (For example, being able to `@Inject Media`).

Also commented out the Orientation addition within `MetaDataHelper.java` (line 32).
The logic here is that as a user, seeing "Orientation: 0" doesn't really hold much meaning. 
It would seem to me that this can be done in another "ticket" to find a workaround to provide the user with meaningful input on what orientation the photo is, but that is out of the scope of this ticket. 


*Includes other minor code cleanup details in the affected classes.