### PR TITLE
Fix wrong resolution in metadata

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/data/metadata/MetadataHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/metadata/MetadataHelper.java
@@ -30,7 +30,7 @@ public class MetadataHelper {
         // TODO should i add this always?
         details.put(context.getString(R.string.orientation), m.getOrientation() + "");
         try {
-            MetaDataItem metadata = MetaDataItem.getMetadata(context.getContentResolver().openInputStream(m.getUri()));
+            MetaDataItem metadata = MetaDataItem.getMetadata(context, m.getUri());
             details.put(context.getString(R.string.resolution), metadata.getResolution());
             details.put(context.getString(R.string.date), SimpleDateFormat.getDateTimeInstance().format(new Date(m.getDateModified())));
             Date dateOriginal = metadata.getDateOriginal();

--- a/app/src/main/java/org/horaapps/leafpic/data/metadata/MetadataHelper.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/metadata/MetadataHelper.java
@@ -29,25 +29,22 @@ public class MetadataHelper {
             details.put(context.getString(R.string.size), StringUtils.humanReadableByteCount(m.getSize(), true));
         // TODO should i add this always?
         details.put(context.getString(R.string.orientation), m.getOrientation() + "");
-        try {
-            MetaDataItem metadata = MetaDataItem.getMetadata(context, m.getUri());
-            details.put(context.getString(R.string.resolution), metadata.getResolution());
-            details.put(context.getString(R.string.date), SimpleDateFormat.getDateTimeInstance().format(new Date(m.getDateModified())));
-            Date dateOriginal = metadata.getDateOriginal();
-            if (dateOriginal != null )
-                details.put(context.getString(R.string.date_taken), SimpleDateFormat.getDateTimeInstance().format(dateOriginal));
+        MetaDataItem metadata = MetaDataItem.getMetadata(context, m.getUri());
+        details.put(context.getString(R.string.resolution), metadata.getResolution());
+        details.put(context.getString(R.string.date), SimpleDateFormat.getDateTimeInstance().format(new Date(m.getDateModified())));
+        Date dateOriginal = metadata.getDateOriginal();
+        if (dateOriginal != null)
+            details.put(context.getString(R.string.date_taken), SimpleDateFormat.getDateTimeInstance().format(dateOriginal));
 
-            String tmp;
-            if ((tmp = metadata.getCameraInfo()) != null)
-                details.put(context.getString(R.string.camera), tmp);
-            if ((tmp = metadata.getExifInfo()) != null)
-                details.put(context.getString(R.string.exif), tmp);
-            GeoLocation location;
-            if ((location = metadata.getLocation()) != null)
-                details.put(context.getString(R.string.location), location.toDMSString());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        String tmp;
+        if ((tmp = metadata.getCameraInfo()) != null)
+            details.put(context.getString(R.string.camera), tmp);
+        if ((tmp = metadata.getExifInfo()) != null)
+            details.put(context.getString(R.string.exif), tmp);
+        GeoLocation location;
+        if ((location = metadata.getLocation()) != null)
+            details.put(context.getString(R.string.location), location.toDMSString());
+
 
         return details;
     }


### PR DESCRIPTION
Function BitmapFactory.decodeStream() need a fresh new input stream to correctly parse bitmap. Passing the input stream used by function ImageMetadataReader.readMetadata() to BitmapFactory.decodeStream() does not work. Refactor the code so function BitmapFactory.decodeStream() has a chance to use a dedicated input stream.