### PR TITLE
Fix this rate app feature. 

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/about/AboutActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/about/AboutActivity.java
@@ -101,12 +101,6 @@ public class AboutActivity extends ThemedActivity implements ContactListener {
 
     @OnClick(R.id.about_link_rate)
     public void onRate() {
-
-//        //Until app is released this will not work because of conflicting package names
-//        Intent intent = new Intent(Intent.ACTION_VIEW);
-//        //intent.setData(Uri.parse("market://details?id="+getPackageName()));
-//        intent.setData(Uri.parse("https://play.google.com/store/apps/details?id=org.horaapps.leafpic"));
-//        startActivity(intent);
         Uri uri = Uri.parse("market://details?id=org.horaapps.leafpic");
         Intent goToMarket = new Intent(Intent.ACTION_VIEW, uri);
         // To count with Play market backstack, After pressing back button,

--- a/app/src/main/java/org/horaapps/leafpic/about/AboutActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/about/AboutActivity.java
@@ -102,10 +102,24 @@ public class AboutActivity extends ThemedActivity implements ContactListener {
     @OnClick(R.id.about_link_rate)
     public void onRate() {
 
-        //Until app is released this will not work because of conflicting package names
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(Uri.parse("market://details?id="+getPackageName()));
-        startActivity(intent);
+//        //Until app is released this will not work because of conflicting package names
+//        Intent intent = new Intent(Intent.ACTION_VIEW);
+//        //intent.setData(Uri.parse("market://details?id="+getPackageName()));
+//        intent.setData(Uri.parse("https://play.google.com/store/apps/details?id=org.horaapps.leafpic"));
+//        startActivity(intent);
+        Uri uri = Uri.parse("market://details?id=org.horaapps.leafpic");
+        Intent goToMarket = new Intent(Intent.ACTION_VIEW, uri);
+        // To count with Play market backstack, After pressing back button,
+        // to taken back to our application, we need to add following flags to intent.
+        goToMarket.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY |
+                Intent.FLAG_ACTIVITY_NEW_DOCUMENT |
+                Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+        try {
+            startActivity(goToMarket);
+        } catch (ActivityNotFoundException e) {
+            startActivity(new Intent(Intent.ACTION_VIEW,
+                    Uri.parse("http://play.google.com/store/apps/details?id=org.horaapps.leafpic" )));
+        }
     }
 
     @OnClick(R.id.about_link_github)


### PR DESCRIPTION
Hi. I've just fixed issue #539. I gave up 'getPackageName()' function to get app's id. Instead I used app's id directly. I have no idea why 'getPackageName()' doesn't work here. I'm still figuring out the reason. 
Also, I took references in:
https://stackoverflow.com/questions/10816757/rate-this-app-link-in-google-play-store-app-on-the-phone
The additional code here is to open rate page through web browser if the phone doesn't have Google Play Store app. 
I hope my work will be helpful for you.
By the way. I love this app. It runs very smooth in my three years old phone and it's functional. Great job!