### PR TITLE
Added Timeline Support via Experimental setting

### DIFF
--- a/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
+++ b/app/src/main/java/org/horaapps/leafpic/activities/SingleMediaActivity.java
@@ -60,6 +60,7 @@ import org.horaapps.leafpic.fragments.BaseMediaFragment;
 import org.horaapps.leafpic.fragments.ImageFragment;
 import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.AnimationUtils;
+import org.horaapps.leafpic.util.DeviceUtils;
 import org.horaapps.leafpic.util.LegacyCompatFileProvider;
 import org.horaapps.leafpic.util.Measure;
 import org.horaapps.leafpic.util.Security;
@@ -398,7 +399,7 @@ public class SingleMediaActivity extends SharedMediaActivity implements BaseMedi
         super.onConfigurationChanged(newConfig);
         RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(
                 RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT);
-        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE)
+        if (DeviceUtils.isLandscape(getResources()))
             params.setMargins(0, 0, Measure.getNavigationBarSize(SingleMediaActivity.this).x, 0);
         else
             params.setMargins(0, 0, 0, 0);

--- a/app/src/main/java/org/horaapps/leafpic/adapters/MediaAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/adapters/MediaAdapter.java
@@ -33,6 +33,7 @@ import org.horaapps.liz.ui.ThemedIcon;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import butterknife.BindView;
@@ -321,6 +322,12 @@ public class MediaAdapter extends ThemedAdapter<MediaAdapter.ViewHolder> {
 
     public void clear() {
         media.clear();
+        notifyDataSetChanged();
+    }
+
+    public void setMedia(@NonNull List<Media> mediaList) {
+        media.clear();
+        media.addAll(mediaList);
         notifyDataSetChanged();
     }
 

--- a/app/src/main/java/org/horaapps/leafpic/data/Album.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/Album.java
@@ -70,7 +70,7 @@ public class Album implements CursorHandler, Parcelable {
 	}
 
 	@Override
-	public Album handle(Cursor cur) throws SQLException {
+	public Album handle(Cursor cur) {
 		return new Album(cur);
 	}
 

--- a/app/src/main/java/org/horaapps/leafpic/data/CursorHandler.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/CursorHandler.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
  */
 
 public interface CursorHandler<T> {
-    T handle(Cursor cu) throws SQLException;
+    T handle(Cursor cu);
     static String [] getProjection() {
         return new String[0];
     }

--- a/app/src/main/java/org/horaapps/leafpic/data/Media.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/Media.java
@@ -3,7 +3,7 @@ package org.horaapps.leafpic.data;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.media.ExifInterface;
+import android.support.media.ExifInterface;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -13,17 +13,33 @@ import com.bumptech.glide.signature.ObjectKey;
 import com.drew.lang.GeoLocation;
 import com.drew.lang.annotations.NotNull;
 
+import org.horaapps.leafpic.timeline.data.TimelineItem;
+import org.horaapps.leafpic.util.ArrayUtils;
 import org.horaapps.leafpic.util.MimeTypeUtils;
 import org.horaapps.leafpic.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.SQLException;
 
-/**
- * Created by dnld on 26/04/16.
- */
-public class Media implements CursorHandler, Parcelable {
+// TODO Calvin: Separate out the logic here
+// Ideally, we should have separate data classes for images, videos & gifs
+// Base class can be Media, and others should extend
+// Try to separate out Database logic and projections from this class
+public class Media implements TimelineItem, CursorHandler, Parcelable {
+
+    private static final String[] sProjection = new String[] {
+            MediaStore.Images.Media.DATA,
+            MediaStore.Images.Media.DATE_TAKEN,
+            MediaStore.Images.Media.MIME_TYPE,
+            MediaStore.Images.Media.SIZE,
+            MediaStore.Images.Media.ORIENTATION
+    };
+
+    private static final int CURSOR_POS_DATA = ArrayUtils.getIndex(sProjection, MediaStore.Images.Media.DATA);
+    private static final int CURSOR_POS_DATE_TAKEN = ArrayUtils.getIndex(sProjection, MediaStore.Images.Media.DATE_TAKEN);
+    private static final int CURSOR_POS_MIME_TYPE = ArrayUtils.getIndex(sProjection, MediaStore.Images.Media.MIME_TYPE);
+    private static final int CURSOR_POS_SIZE = ArrayUtils.getIndex(sProjection, MediaStore.Images.Media.SIZE);
+    private static final int CURSOR_POS_ORIENTATION = ArrayUtils.getIndex(sProjection, MediaStore.Images.Media.ORIENTATION);
 
     private String path = null;
     private long dateModified = -1;
@@ -35,7 +51,8 @@ public class Media implements CursorHandler, Parcelable {
     private long size = -1;
     private boolean selected = false;
 
-    public Media() { }
+    public Media() {
+    }
 
     public Media(String path, long dateModified) {
         this.path = path;
@@ -60,26 +77,20 @@ public class Media implements CursorHandler, Parcelable {
     }
 
     public Media(@NotNull Cursor cur) {
-        this.path = cur.getString(0);
-        this.dateModified = cur.getLong(1);
-        this.mimeType = cur.getString(2);
-        this.size = cur.getLong(3);
-        this.orientation = cur.getInt(4);
+        this.path = cur.getString(CURSOR_POS_DATA);
+        this.dateModified = cur.getLong(CURSOR_POS_DATE_TAKEN);
+        this.mimeType = cur.getString(CURSOR_POS_MIME_TYPE);
+        this.size = cur.getLong(CURSOR_POS_SIZE);
+        this.orientation = cur.getInt(CURSOR_POS_ORIENTATION);
     }
 
     @Override
-    public Media handle(Cursor cu) throws SQLException {
+    public Media handle(Cursor cu) {
         return new Media(cu);
     }
 
     public static String[] getProjection() {
-        return new String[]{
-                MediaStore.Images.Media.DATA,
-                MediaStore.Images.Media.DATE_TAKEN,
-                MediaStore.Images.Media.MIME_TYPE,
-                MediaStore.Images.Media.SIZE,
-                MediaStore.Images.Media.ORIENTATION
-        };
+        return sProjection;
     }
 
     public void setUri(String uriString) {
@@ -109,11 +120,17 @@ public class Media implements CursorHandler, Parcelable {
         return selected;
     }
 
-    public boolean isGif() { return mimeType.endsWith("gif"); }
+    public boolean isGif() {
+        return mimeType.endsWith("gif");
+    }
 
-    public boolean isImage() { return mimeType.startsWith("image"); }
+    public boolean isImage() {
+        return mimeType.startsWith("image");
+    }
 
-    public boolean isVideo() { return mimeType.startsWith("video"); }
+    public boolean isVideo() {
+        return mimeType.startsWith("video");
+    }
 
     public Uri getUri() {
         return uriString != null ? Uri.parse(uriString) : Uri.fromFile(new File(path));
@@ -151,14 +168,15 @@ public class Media implements CursorHandler, Parcelable {
     //<editor-fold desc="Exif & More">
 // TODO remove from here!
     @Deprecated
-    public Bitmap getBitmap(){
+    public Bitmap getBitmap() {
         BitmapFactory.Options bmOptions = new BitmapFactory.Options();
         Bitmap bitmap = BitmapFactory.decodeFile(path, bmOptions);
-        bitmap = Bitmap.createScaledBitmap(bitmap,bitmap.getWidth(),bitmap.getHeight(),true);
+        bitmap = Bitmap.createScaledBitmap(bitmap, bitmap.getWidth(), bitmap.getHeight(), true);
         return bitmap;
     }
+
     @Deprecated
-    public GeoLocation getGeoLocation()  {
+    public GeoLocation getGeoLocation() {
         return /*metadata != null ? metadata.getLocation() :*/ null;
     }
 
@@ -171,19 +189,27 @@ public class Media implements CursorHandler, Parcelable {
             public void run() {
                 int exifOrientation = -1;
                 try {
-                    ExifInterface  exif = new ExifInterface(path);
+                    ExifInterface exif = new ExifInterface(path);
                     switch (orientation) {
-                        case 90: exifOrientation = ExifInterface.ORIENTATION_ROTATE_90; break;
-                        case 180: exifOrientation = ExifInterface.ORIENTATION_ROTATE_180; break;
-                        case 270: exifOrientation = ExifInterface.ORIENTATION_ROTATE_270; break;
-                        case 0: exifOrientation = ExifInterface.ORIENTATION_NORMAL; break;
+                        case 90:
+                            exifOrientation = ExifInterface.ORIENTATION_ROTATE_90;
+                            break;
+                        case 180:
+                            exifOrientation = ExifInterface.ORIENTATION_ROTATE_180;
+                            break;
+                        case 270:
+                            exifOrientation = ExifInterface.ORIENTATION_ROTATE_270;
+                            break;
+                        case 0:
+                            exifOrientation = ExifInterface.ORIENTATION_NORMAL;
+                            break;
                     }
                     if (exifOrientation != -1) {
                         exif.setAttribute(ExifInterface.TAG_ORIENTATION, String.valueOf(exifOrientation));
                         exif.saveAttributes();
                     }
+                } catch (IOException ignored) {
                 }
-                catch (IOException ignored) {  }
             }
         }).start();
         return true;
@@ -207,9 +233,9 @@ public class Media implements CursorHandler, Parcelable {
     }
 
     @Deprecated
-    public boolean fixDate(){
+    public boolean fixDate() {
         long newDate = getDateTaken();
-        if (newDate != -1){
+        if (newDate != -1) {
             File f = new File(path);
             if (f.setLastModified(newDate)) {
                 dateModified = newDate;
@@ -266,4 +292,9 @@ public class Media implements CursorHandler, Parcelable {
             return new Media[size];
         }
     };
+
+    @Override
+    public int getTimelineType() {
+        return TYPE_MEDIA;
+    }
 }

--- a/app/src/main/java/org/horaapps/leafpic/data/sort/MediaComparators.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/sort/MediaComparators.java
@@ -1,7 +1,10 @@
 package org.horaapps.leafpic.data.sort;
 
+import android.support.annotation.NonNull;
+
 import org.horaapps.leafpic.data.AlbumSettings;
 import org.horaapps.leafpic.data.Media;
+import org.horaapps.leafpic.timeline.data.TimelineHeaderModel;
 import org.horaapps.leafpic.util.NumericComparator;
 
 import java.util.Comparator;
@@ -15,9 +18,14 @@ public class MediaComparators {
     public static Comparator<Media> getComparator(AlbumSettings settings) {
         return getComparator(settings.getSortingMode(), settings.getSortingOrder());
     }
+
     public static Comparator<Media> getComparator(SortingMode sortingMode, SortingOrder sortingOrder) {
-        return  sortingOrder == SortingOrder.ASCENDING
+        return sortingOrder == SortingOrder.ASCENDING
                 ? getComparator(sortingMode) : reverse(getComparator(sortingMode));
+    }
+
+    public static Comparator<TimelineHeaderModel> getTimelineComparator(@NonNull SortingOrder sortingOrder) {
+        return sortingOrder.isAscending() ? getTimelineComparator() : reverse(getTimelineComparator());
     }
 
     public static Comparator<Media> getComparator(SortingMode sortingMode) {
@@ -30,11 +38,11 @@ public class MediaComparators {
         }
     }
 
-    private static Comparator<Media> reverse(Comparator<Media> comparator) {
+    private static <T> Comparator<T> reverse(Comparator<T> comparator) {
         return (o1, o2) -> comparator.compare(o2, o1);
     }
 
-    private static Comparator<Media> getDateComparator(){
+    private static Comparator<Media> getDateComparator() {
         return (f1, f2) -> f1.getDateModified().compareTo(f2.getDateModified());
     }
 
@@ -52,5 +60,9 @@ public class MediaComparators {
 
     private static Comparator<Media> getNumericComparator() {
         return (f1, f2) -> NumericComparator.filevercmp(f1.getPath(), f2.getPath());
+    }
+
+    private static Comparator<TimelineHeaderModel> getTimelineComparator() {
+        return (t1, t2) -> t1.getDate().compareTo(t2.getDate());
     }
 }

--- a/app/src/main/java/org/horaapps/leafpic/data/sort/SortingOrder.java
+++ b/app/src/main/java/org/horaapps/leafpic/data/sort/SortingOrder.java
@@ -5,27 +5,27 @@ package org.horaapps.leafpic.data.sort;
  */
 
 public enum SortingOrder {
-  ASCENDING (1), DESCENDING (0);
+    ASCENDING(1), DESCENDING(0);
 
-  int value;
+    int value;
 
-  SortingOrder(int value) {
-    this.value = value;
-  }
+    SortingOrder(int value) {
+        this.value = value;
+    }
 
-  public int getValue() {
-    return value;
-  }
+    public int getValue() {
+        return value;
+    }
 
-  public boolean isAscending(){
-    return value == ASCENDING.getValue();
-  }
+    public boolean isAscending() {
+        return value == ASCENDING.getValue();
+    }
 
-  public static SortingOrder fromValue(boolean value) {
-    return value ? ASCENDING : DESCENDING;
-  }
+    public static SortingOrder fromValue(boolean value) {
+        return value ? ASCENDING : DESCENDING;
+    }
 
-  public static SortingOrder fromValue(int value) {
-    return value == 0 ? DESCENDING : ASCENDING;
-  }
+    public static SortingOrder fromValue(int value) {
+        return value == 0 ? DESCENDING : ASCENDING;
+    }
 }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/AlbumsFragment.java
@@ -36,6 +36,7 @@ import org.horaapps.leafpic.data.sort.SortingMode;
 import org.horaapps.leafpic.data.sort.SortingOrder;
 import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.AnimationUtils;
+import org.horaapps.leafpic.util.DeviceUtils;
 import org.horaapps.leafpic.util.Measure;
 import org.horaapps.leafpic.util.Security;
 import org.horaapps.leafpic.util.preferences.Prefs;
@@ -149,7 +150,7 @@ public class AlbumsFragment extends BaseFragment {
     }
 
     public int columnsCount() {
-        return getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT
+        return DeviceUtils.isPortrait(getResources())
                 ? Prefs.getFolderColumnsPortrait()
                 : Prefs.getFolderColumnsLandscape();
     }

--- a/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/fragments/RvMediaFragment.java
@@ -34,7 +34,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
-import com.orhanobut.hawk.Hawk;
 
 import org.horaapps.leafpic.R;
 import org.horaapps.leafpic.activities.PaletteActivity;
@@ -49,10 +48,12 @@ import org.horaapps.leafpic.data.provider.CPHelper;
 import org.horaapps.leafpic.data.sort.SortingMode;
 import org.horaapps.leafpic.data.sort.SortingOrder;
 import org.horaapps.leafpic.delete.DeleteMediaBottomSheet;
+import org.horaapps.leafpic.interfaces.MediaClickListener;
 import org.horaapps.leafpic.util.Affix;
 import org.horaapps.leafpic.util.AlertDialogsHelper;
 import org.horaapps.leafpic.util.AnimationUtils;
 import org.horaapps.leafpic.util.LegacyCompatFileProvider;
+import org.horaapps.leafpic.util.DeviceUtils;
 import org.horaapps.leafpic.util.Measure;
 import org.horaapps.leafpic.util.MimeTypeUtils;
 import org.horaapps.leafpic.util.StringUtils;
@@ -89,10 +90,6 @@ public class RvMediaFragment extends BaseFragment {
     private GridSpacingItemDecoration spacingDecoration;
 
     private Album album;
-
-    public interface MediaClickListener {
-        void onMediaClick(Album album, ArrayList<Media> media, int position);
-    }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -214,7 +211,7 @@ public class RvMediaFragment extends BaseFragment {
     }
 
     public int columnsCount() {
-        return getResources().getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT
+        return DeviceUtils.isPortrait(getResources())
                 ? Prefs.getMediaColumnsPortrait()
                 : Prefs.getMediaColumnsLandscape();
     }
@@ -498,7 +495,7 @@ public class RvMediaFragment extends BaseFragment {
                 //region Example
                 final LinearLayout llExample = dialogLayout.findViewById(R.id.affix_example);
                 llExample.setBackgroundColor(getBackgroundColor());
-                llExample.setVisibility(Hawk.get("show_tips", true) ? View.VISIBLE : View.GONE);
+                llExample.setVisibility(Prefs.getToggleValue(getContext().getString(R.string.preference_show_tips), true) ? View.VISIBLE : View.GONE);
                 final LinearLayout llExampleH = dialogLayout.findViewById(R.id.affix_example_horizontal);
                 //llExampleH.setBackgroundColor(getCardBackgroundColor());
                 final LinearLayout llExampleV = dialogLayout.findViewById(R.id.affix_example_vertical);

--- a/app/src/main/java/org/horaapps/leafpic/interfaces/MediaClickListener.java
+++ b/app/src/main/java/org/horaapps/leafpic/interfaces/MediaClickListener.java
@@ -1,0 +1,10 @@
+package org.horaapps.leafpic.interfaces;
+
+import org.horaapps.leafpic.data.Album;
+import org.horaapps.leafpic.data.Media;
+
+import java.util.ArrayList;
+
+public interface MediaClickListener {
+    void onMediaClick(Album album, ArrayList<Media> media, int position);
+}

--- a/app/src/main/java/org/horaapps/leafpic/timeline/GroupingMode.java
+++ b/app/src/main/java/org/horaapps/leafpic/timeline/GroupingMode.java
@@ -1,0 +1,126 @@
+package org.horaapps.leafpic.timeline;
+
+import android.support.annotation.NonNull;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Locale;
+
+/**
+ * Grouping for Timeline items.
+ */
+public enum GroupingMode {
+
+    /**
+     * Group the Timeline items by DAY.
+     * eg: All media taken on 23rd October, 1994
+     */
+    DAY {
+        @Override
+        public boolean isInGroup(@NonNull Calendar left, @NonNull Calendar right) {
+            return WEEK.isInGroup(left, right) && isDayOfMonthSame(left, right);
+        }
+
+        @NonNull
+        @Override
+        public String getGroupHeader(@NonNull Calendar calendar) {
+            return getFormattedDate(HEADER_PATTERN_DAY, calendar);
+        }
+    },
+
+    /**
+     * Group the Timeline items by WEEK.
+     * eg: All media taken on 4th week of October, 1994
+     */
+    WEEK {
+        @Override
+        public boolean isInGroup(@NonNull Calendar left, @NonNull Calendar right) {
+            return MONTH.isInGroup(left, right) && isWeekOfMonthSame(left, right);
+        }
+
+        @NonNull
+        @Override
+        public String getGroupHeader(@NonNull Calendar calendar) {
+            return "Week " + getFormattedDate(HEADER_PATTERN_WEEK, calendar);
+        }
+    },
+
+    /**
+     * Group the Timeline items by MONTH.
+     * eg: All media taken in October, 1994.
+     */
+    MONTH {
+        @Override
+        public boolean isInGroup(@NonNull Calendar left, @NonNull Calendar right) {
+            return YEAR.isInGroup(left, right) && isMonthOfYearSame(left, right);
+        }
+
+        @NonNull
+        @Override
+        public String getGroupHeader(@NonNull Calendar calendar) {
+            return getFormattedDate(HEADER_PATTERN_MONTH, calendar);
+        }
+    },
+
+    /**
+     * Group the Timeline items by YEAR.
+     * eg: All media taken in 1994.
+     */
+    YEAR {
+        @Override
+        public boolean isInGroup(@NonNull Calendar left, @NonNull Calendar right) {
+            return isYearSame(left, right);
+        }
+
+        @NonNull
+        @Override
+        public String getGroupHeader(@NonNull Calendar calendar) {
+            return getFormattedDate(HEADER_PATTERN_YEAR, calendar);
+        }
+    };
+
+    // Must be below Enum constants. Consistency, I'm sorry :)
+    private static final String HEADER_PATTERN_DAY = "E, d MMM yyyy";
+    private static final String HEADER_PATTERN_WEEK = "W, MMM yyyy";
+    private static final String HEADER_PATTERN_MONTH = "MMM yyyy";
+    private static final String HEADER_PATTERN_YEAR = "yyyy";
+
+    /**
+     * Check if the Calendar for media items belong in the same group.
+     *
+     * @param left  The calendar instance of media item 1.
+     * @param right The calendar instance of media item 2.
+     * @return A boolean stating if the media items belong to the same group.
+     */
+    public abstract boolean isInGroup(@NonNull Calendar left, @NonNull Calendar right);
+
+    /**
+     * Get a user-readable header for Timeline header items.
+     *
+     * @param calendar The calendar instance to get the header text.
+     * @return A string to show on the Timeline header items.
+     */
+    @NonNull
+    public abstract String getGroupHeader(@NonNull Calendar calendar);
+
+    public boolean isDayOfMonthSame(@NonNull Calendar left, @NonNull Calendar right) {
+        return left.get(Calendar.DAY_OF_MONTH) == right.get(Calendar.DAY_OF_MONTH);
+    }
+
+    public boolean isWeekOfMonthSame(@NonNull Calendar left, @NonNull Calendar right) {
+        return left.get(Calendar.WEEK_OF_MONTH) == right.get(Calendar.WEEK_OF_MONTH);
+    }
+
+    public boolean isMonthOfYearSame(@NonNull Calendar left, @NonNull Calendar right) {
+        return left.get(Calendar.MONTH) == right.get(Calendar.MONTH);
+    }
+
+    public boolean isYearSame(@NonNull Calendar left, @NonNull Calendar right) {
+        return left.get(Calendar.YEAR) == right.get(Calendar.YEAR);
+    }
+
+    @NonNull
+    public String getFormattedDate(@NonNull String formatter, @NonNull Calendar calendar) {
+        return new SimpleDateFormat(formatter, Locale.ENGLISH).format(calendar.getTime());
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/timeline/TimelineAdapter.java
+++ b/app/src/main/java/org/horaapps/leafpic/timeline/TimelineAdapter.java
@@ -1,0 +1,229 @@
+package org.horaapps.leafpic.timeline;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.DimenRes;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.data.Media;
+import org.horaapps.leafpic.data.sort.SortingOrder;
+import org.horaapps.leafpic.timeline.data.TimelineHeaderModel;
+import org.horaapps.leafpic.timeline.data.TimelineItem;
+import org.horaapps.liz.ThemeHelper;
+import org.horaapps.liz.ThemedAdapter;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import io.reactivex.Observable;
+import io.reactivex.subjects.PublishSubject;
+
+import static org.horaapps.leafpic.timeline.ViewHolder.TimelineHeaderViewHolder;
+import static org.horaapps.leafpic.timeline.ViewHolder.TimelineMediaViewHolder;
+import static org.horaapps.leafpic.timeline.ViewHolder.TimelineViewHolder;
+
+/**
+ * Adapter for showing Timeline.
+ */
+public class TimelineAdapter extends ThemedAdapter<TimelineViewHolder> {
+
+    private List<TimelineItem> timelineItems;
+    private ArrayList<Media> mediaItems;
+    private static Drawable mediaPlaceholder;
+
+    private final PublishSubject<Integer> onClickSubject = PublishSubject.create();
+    private SortingOrder sortingOrder;
+    private GroupingMode groupingMode;
+    private int timelineGridSize;
+
+    public TimelineAdapter(@NonNull Context context, int timelineGridSize) {
+        super(context);
+        timelineItems = new ArrayList<>();
+        this.timelineGridSize = timelineGridSize;
+
+        this.sortingOrder = SortingOrder.DESCENDING;
+    }
+
+    public ArrayList<Media> getMedia() {
+        return mediaItems;
+    }
+
+    public boolean clearSelected() {
+        return true;
+    }
+
+    /**
+     * Set the grouping mode (DAY, WEEK, MONTH, YEAR) of the Timeline.
+     */
+    public void setGroupingMode(@NonNull GroupingMode groupingMode) {
+        this.groupingMode = groupingMode;
+
+        if (mediaItems == null) return;
+
+        // Rebuild the Timeline Items
+        buildTimelineItems();
+    }
+
+    /**
+     * Set the sorting order (ASCENDING, DESCENDING) of the Timeline.
+     */
+    public void setSortingOrder(@NonNull SortingOrder sortingOrder) {
+        this.sortingOrder = sortingOrder;
+        notifyDataSetChanged();
+    }
+
+    public void setTimelineGridSize(int timelineGridSize) {
+        this.timelineGridSize = timelineGridSize;
+    }
+
+    @Override
+    public ViewHolder.TimelineViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        Context context = parent.getContext();
+        if (viewType == TimelineItem.TYPE_HEADER) {
+            return new TimelineHeaderViewHolder(LayoutInflater.from(context).inflate(
+                    R.layout.view_timeline_header,
+                    parent,
+                    false));
+
+        } else if (viewType == TimelineItem.TYPE_MEDIA) {
+            return new TimelineMediaViewHolder(LayoutInflater.from(context).inflate(
+                    R.layout.card_photo,
+                    parent,
+                    false),
+                    ThemeHelper.getPlaceHolder(context));
+        }
+        return null;
+    }
+
+    public void setGridLayoutManager(GridLayoutManager gridLayoutManager) {
+        gridLayoutManager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
+            @Override
+            public int getSpanSize(int position) {
+                TimelineItem timelineItem = getItem(position);
+
+                // If we have a header item, occupy the entire width
+                if (timelineItem.getTimelineType() == TimelineItem.TYPE_HEADER) return timelineGridSize;
+
+                // Else, a media item takes up a single space
+                return 1;
+            }
+        });
+    }
+
+    private void clearAll() {
+        timelineItems.clear();
+    }
+
+    public boolean selecting() {
+        return false;
+    }
+
+    public Observable<Integer> getClicks() {
+        return onClickSubject;
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return getItem(position).getTimelineType();
+    }
+
+    @NonNull
+    private TimelineItem getItem(int position) {
+        return timelineItems.get(position);
+    }
+
+    @Override
+    public void onBindViewHolder(TimelineViewHolder viewHolder, int position) {
+        TimelineItem timelineItem = getItem(position);
+
+        if (viewHolder instanceof TimelineHeaderViewHolder) {
+            TimelineHeaderViewHolder headerViewHolder = (TimelineHeaderViewHolder) viewHolder;
+            headerViewHolder.bind((TimelineHeaderModel) timelineItem);
+        } else if (viewHolder instanceof TimelineMediaViewHolder) {
+            TimelineMediaViewHolder mediaHolder = (TimelineMediaViewHolder) viewHolder;
+            mediaHolder.bind((Media) timelineItem);
+
+            mediaHolder.layout.setOnClickListener(v -> {
+                // Find this element's position in Media Items
+                for (int pos = 0; pos < mediaItems.size(); pos++) {
+                    Media mediaItem = mediaItems.get(pos);
+                    if (mediaItem.equals(timelineItem)) {
+                        onClickSubject.onNext(pos);
+                        return;
+                    }
+                }
+            });
+        }
+    }
+
+    public void setMedia(@NonNull ArrayList<Media> mediaList) {
+        mediaItems = mediaList;
+        buildTimelineItems();
+    }
+
+    private void buildTimelineItems() {
+        clearAll();
+        timelineItems = getTimelineItems(mediaItems);
+        notifyDataSetChanged();
+    }
+
+    /**
+     * Get the list of Timeline Items to show.
+     * Internally adds the headers to the list.
+     *
+     * @param mediaList The list of media items to show.
+     * @return A list with headers to be inflated for Timeline.
+     */
+    private List<TimelineItem> getTimelineItems(@NonNull List<Media> mediaList) {
+        // Preprocessing - Add headers in the list of media
+        // TODO: Think of ways to optimise / improve this logic
+
+        List<TimelineItem> timelineItemList = new ArrayList<>();
+
+        int headersAdded = 0;
+        Calendar currentDate = null;
+        for (int position = 0; position < mediaList.size(); position++) {
+            Calendar mediaDate = new GregorianCalendar();
+            mediaDate.setTimeInMillis(mediaList.get(position).getDateModified());
+            if (currentDate == null || !groupingMode.isInGroup(currentDate, mediaDate)) {
+                currentDate = mediaDate;
+                TimelineHeaderModel timelineHeaderModel = new TimelineHeaderModel(mediaDate);
+                timelineHeaderModel.setHeaderText(groupingMode.getGroupHeader(mediaDate));
+                timelineItemList.add(position + headersAdded, timelineHeaderModel);
+                headersAdded++;
+            }
+
+            timelineItemList.add(mediaList.get(position));
+        }
+        return timelineItemList;
+    }
+
+    @Override
+    public int getItemCount() {
+        return timelineItems.size();
+    }
+
+    public static class TimelineItemDecorator extends RecyclerView.ItemDecoration {
+
+        private int pixelOffset;
+
+        public TimelineItemDecorator(@NonNull Context context, @DimenRes int dimenRes) {
+            pixelOffset = context.getResources().getDimensionPixelOffset(dimenRes);
+        }
+
+        @Override
+        public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
+            super.getItemOffsets(outRect, view, parent, state);
+            outRect.set(pixelOffset, pixelOffset, pixelOffset, pixelOffset);
+        }
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/timeline/TimelineFragment.java
+++ b/app/src/main/java/org/horaapps/leafpic/timeline/TimelineFragment.java
@@ -1,0 +1,248 @@
+package org.horaapps.leafpic.timeline;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.data.Album;
+import org.horaapps.leafpic.data.Media;
+import org.horaapps.leafpic.data.filter.MediaFilter;
+import org.horaapps.leafpic.data.provider.CPHelper;
+import org.horaapps.leafpic.data.sort.MediaComparators;
+import org.horaapps.leafpic.data.sort.SortingMode;
+import org.horaapps.leafpic.data.sort.SortingOrder;
+import org.horaapps.leafpic.fragments.BaseFragment;
+import org.horaapps.leafpic.fragments.RvMediaFragment;
+import org.horaapps.leafpic.interfaces.MediaClickListener;
+import org.horaapps.leafpic.items.ActionsListener;
+import org.horaapps.leafpic.util.DeviceUtils;
+import org.horaapps.leafpic.util.preferences.Defaults;
+import org.horaapps.liz.ThemeHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.schedulers.Schedulers;
+
+/**
+ * Fragment which shows the Timeline.
+ */
+public class TimelineFragment extends BaseFragment {
+
+    public static final String TAG = "TimelineFragment";
+
+    private static final String ARGS_ALBUM = "args_album";
+
+    private static final String KEY_ALBUM = "key_album";
+    private static final String KEY_GROUPING_MODE = "key_grouping_mode";
+
+    @BindView(R.id.timeline_items) RecyclerView timelineItems;
+    @BindView(R.id.timeline_swipe_refresh_layout) SwipeRefreshLayout refreshLayout;
+
+    private TimelineAdapter timelineAdapter;
+    private MediaClickListener timelineListener;
+    private GridLayoutManager gridLayoutManager;
+
+    private Album contentAlbum;
+
+    private GroupingMode groupingMode;
+
+    public static TimelineFragment newInstance(@NonNull Album album) {
+        TimelineFragment fragment = new TimelineFragment();
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(ARGS_ALBUM, album);
+        fragment.setArguments(bundle);
+        return fragment;
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof MediaClickListener) {
+            timelineListener = (MediaClickListener) context;
+        }
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setHasOptionsMenu(true);
+
+        if (savedInstanceState != null) {
+            contentAlbum = savedInstanceState.getParcelable(KEY_ALBUM);
+            groupingMode = (GroupingMode) savedInstanceState.get(KEY_GROUPING_MODE);
+            return;
+        }
+
+        // Get content from arguments
+        Bundle arguments = getArguments();
+        if (arguments == null) return;
+        contentAlbum = arguments.getParcelable(ARGS_ALBUM);
+        groupingMode = GroupingMode.DAY; // Default
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+
+        View rootView = inflater.inflate(R.layout.fragment_timeline, container, false);
+        ButterKnife.bind(this, rootView);
+        return rootView;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        refreshLayout.setOnRefreshListener(this::loadAlbum);
+        setupRecyclerView();
+        loadAlbum();
+    }
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull Menu menu, @NonNull MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_timeline, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        GroupingMode selectedGrouping = getGroupingMode(item.getItemId());
+        if (selectedGrouping == null) return false;
+
+        groupingMode = selectedGrouping;
+        timelineAdapter.setGroupingMode(groupingMode);
+        item.setChecked(true);
+        return true;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putParcelable(KEY_ALBUM, contentAlbum);
+        outState.putSerializable(KEY_GROUPING_MODE, groupingMode);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Nullable
+    private GroupingMode getGroupingMode(@IdRes int menuId) {
+        switch (menuId) {
+            case R.id.timeline_grouping_day:
+                return GroupingMode.DAY;
+            case R.id.timeline_grouping_week:
+                return GroupingMode.WEEK;
+            case R.id.timeline_grouping_month:
+                return GroupingMode.MONTH;
+            case R.id.timeline_grouping_year:
+                return GroupingMode.YEAR;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        int gridSize = getTimelineGridSize();
+        timelineAdapter.setTimelineGridSize(gridSize);
+        gridLayoutManager.setSpanCount(gridSize);
+    }
+
+    private void setupRecyclerView() {
+        TimelineAdapter.TimelineItemDecorator decorator = new TimelineAdapter.TimelineItemDecorator(getContext(), R.dimen.timeline_decorator_spacing);
+        gridLayoutManager = new GridLayoutManager(getContext(), getTimelineGridSize());
+        timelineItems.setLayoutManager(gridLayoutManager);
+        timelineItems.addItemDecoration(decorator);
+
+        timelineAdapter = new TimelineAdapter(getContext(), getTimelineGridSize());
+        timelineAdapter.setGridLayoutManager(gridLayoutManager);
+        timelineAdapter.setGroupingMode(groupingMode);
+        timelineAdapter.getClicks()
+                .subscribeOn(Schedulers.newThread())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(pos -> {
+                    if (timelineListener != null) {
+                        timelineListener.onMediaClick(contentAlbum, timelineAdapter.getMedia(), pos);
+                    }
+                });
+
+        timelineItems.setAdapter(timelineAdapter);
+    }
+
+    private void loadAlbum() {
+        ArrayList<Media> mediaList = new ArrayList<>();
+        CPHelper.getMedia(getContext(), contentAlbum)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .filter(media -> MediaFilter.getFilter(contentAlbum.filterMode()).accept(media))
+                .subscribe(mediaList::add,
+                        throwable -> refreshLayout.setRefreshing(false),
+                        () -> {
+                            contentAlbum.setCount(mediaList.size());
+                            refreshLayout.setRefreshing(false);
+                            setAdapterMedia(mediaList);
+                        });
+    }
+
+    private void setAdapterMedia(@NonNull ArrayList<Media> mediaList) {
+        Collections.sort(mediaList, MediaComparators.getComparator(SortingMode.DATE, SortingOrder.DESCENDING));
+        timelineAdapter.setMedia(mediaList);
+    }
+
+    private int getTimelineGridSize() {
+        return DeviceUtils.isPortrait(getResources())
+                ? Defaults.TIMELINE_ITEMS_PORTRAIT
+                : Defaults.TIMELINE_ITEMS_LANDSCAPE;
+    }
+
+    @Override
+    public boolean editMode() {
+        return timelineAdapter.selecting();
+    }
+
+    @Override
+    public boolean clearSelected() {
+        return timelineAdapter.clearSelected();
+    }
+
+    @Override
+    public void refreshTheme(ThemeHelper t) {
+        timelineItems.setBackgroundColor(t.getBackgroundColor());
+        timelineAdapter.refreshTheme(t);
+        refreshLayout.setColorSchemeColors(t.getAccentColor());
+        refreshLayout.setProgressBackgroundColorSchemeColor(t.getBackgroundColor());
+    }
+
+    @Override
+    public void onItemSelected(int position) {
+        if (timelineListener != null) {
+            timelineListener.onMediaClick(contentAlbum, timelineAdapter.getMedia(), position);
+        }
+    }
+
+    @Override
+    public void onSelectMode(boolean selectMode) {
+        // TODO: Implement via this interface
+    }
+
+    @Override
+    public void onSelectionCountChanged(int selectionCount, int totalCount) {
+        // TODO: Implement via this interface
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/timeline/ViewHolder.java
+++ b/app/src/main/java/org/horaapps/leafpic/timeline/ViewHolder.java
@@ -1,0 +1,131 @@
+package org.horaapps.leafpic.timeline;
+
+import android.graphics.Color;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.load.DecodeFormat;
+import com.bumptech.glide.load.engine.DiskCacheStrategy;
+import com.bumptech.glide.request.RequestOptions;
+import com.mikepenz.community_material_typeface_library.CommunityMaterial;
+
+import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.data.Media;
+import org.horaapps.leafpic.timeline.data.TimelineHeaderModel;
+import org.horaapps.leafpic.views.SquareRelativeLayout;
+import org.horaapps.liz.ThemeHelper;
+import org.horaapps.liz.ThemedViewHolder;
+import org.horaapps.liz.ui.ThemedIcon;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Class for holding the RecyclerView ViewHolders to be used in Timeline.
+ */
+public class ViewHolder {
+
+    static abstract class TimelineViewHolder extends ThemedViewHolder {
+
+        TimelineViewHolder(View view) {
+            super(view);
+        }
+    }
+
+    /**
+     * ViewHolder for the Timeline headers
+     */
+    protected static class TimelineHeaderViewHolder extends TimelineViewHolder {
+
+        @BindView(R.id.timeline_container_header) TextView headerText;
+
+        TimelineHeaderViewHolder(View view) {
+            super(view);
+            ButterKnife.bind(this, view);
+        }
+
+        void bind(@NonNull TimelineHeaderModel timelineHeaderModel) {
+            headerText.setText(timelineHeaderModel.getHeaderText());
+        }
+
+        @Override
+        public void refreshTheme(ThemeHelper themeHelper) {
+            headerText.setTextColor(themeHelper.getTextColor());
+        }
+    }
+
+    /**
+     * ViewHolder for the Media items.
+     */
+    protected static class TimelineMediaViewHolder extends TimelineViewHolder {
+
+        @BindView(R.id.photo_preview) ImageView imageView;
+        @BindView(R.id.photo_path) TextView path;
+        @BindView(R.id.gif_icon) ThemedIcon gifIcon;
+        @BindView(R.id.icon) ThemedIcon icon;
+        @BindView(R.id.media_card_layout) SquareRelativeLayout layout;
+
+        private Drawable placeholderImage;
+
+        @Override
+        public void refreshTheme(ThemeHelper themeHelper) {
+            icon.setColor(Color.WHITE);
+        }
+
+        TimelineMediaViewHolder(View view, @NonNull Drawable placeholder) {
+            super(view);
+            ButterKnife.bind(this, view);
+            this.placeholderImage = placeholder;
+        }
+
+        void bind(@NonNull Media mediaItem) {
+            // TODO: Refactor this logic!
+            icon.setVisibility(View.GONE);
+            gifIcon.setVisibility(mediaItem.isGif() ? View.VISIBLE : View.GONE);
+
+            RequestOptions options = new RequestOptions()
+                    .signature(mediaItem.getSignature())
+                    .format(DecodeFormat.PREFER_RGB_565)
+                    .centerCrop()
+                    .placeholder(placeholderImage)
+                    .diskCacheStrategy(DiskCacheStrategy.ALL);
+
+            Glide.with(imageView.getContext())
+                    .load(mediaItem.getUri())
+                    .apply(options)
+                    .thumbnail(0.5f)
+                    .into(imageView);
+
+            if (mediaItem.isVideo()) {
+                icon.setVisibility(View.VISIBLE);
+                path.setVisibility(View.VISIBLE);
+                path.setText(mediaItem.getName());
+                icon.animate().alpha(1).setDuration(250);
+                path.animate().alpha(1).setDuration(250);
+            } else {
+                icon.setVisibility(View.GONE);
+                path.setVisibility(View.GONE);
+
+                icon.animate().alpha(0).setDuration(250);
+                path.animate().alpha(0).setDuration(250);
+            }
+
+            if (mediaItem.isSelected()) {
+                icon.setIcon(CommunityMaterial.Icon.cmd_check);
+                icon.setVisibility(View.VISIBLE);
+                imageView.setColorFilter(0x88000000, PorterDuff.Mode.SRC_ATOP);
+                layout.setPadding(15, 15, 15, 15);
+                //ANIMS
+                icon.animate().alpha(1).setDuration(250);
+            } else {
+                imageView.clearColorFilter();
+                layout.setPadding(0, 0, 0, 0);
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/timeline/data/TimelineHeaderModel.java
+++ b/app/src/main/java/org/horaapps/leafpic/timeline/data/TimelineHeaderModel.java
@@ -1,0 +1,49 @@
+package org.horaapps.leafpic.timeline.data;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+/**
+ * Model for showing the Timeline headers.
+ */
+public class TimelineHeaderModel implements TimelineItem {
+
+    private Calendar calendar;
+    private String headerText;
+
+    public TimelineHeaderModel(@NonNull Date date) {
+        this(date.getTime());
+    }
+
+    public TimelineHeaderModel(long timeInMillis) {
+        calendar = new GregorianCalendar();
+        calendar.setTimeInMillis(timeInMillis);
+    }
+
+    public TimelineHeaderModel(@NonNull Calendar calendar) {
+        this.calendar = calendar;
+    }
+
+    public void setHeaderText(@NonNull String headerText) {
+        this.headerText = headerText;
+    }
+
+    @NonNull
+    public Calendar getDate() {
+        return calendar;
+    }
+
+    @Nullable
+    public String getHeaderText() {
+        return headerText;
+    }
+
+    @Override
+    public int getTimelineType() {
+        return TYPE_HEADER;
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/timeline/data/TimelineItem.java
+++ b/app/src/main/java/org/horaapps/leafpic/timeline/data/TimelineItem.java
@@ -1,0 +1,18 @@
+package org.horaapps.leafpic.timeline.data;
+
+import android.support.annotation.IntDef;
+
+/**
+ * Interface to define that this item is capable of being displayed on timeline
+ */
+public interface TimelineItem {
+
+    int TYPE_HEADER = 101;
+    int TYPE_MEDIA = 102;
+
+    @IntDef({TYPE_HEADER, TYPE_MEDIA})
+    @interface TimelineItemType {}
+
+    @TimelineItemType
+    int getTimelineType();
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/ApplicationUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/ApplicationUtils.java
@@ -28,4 +28,8 @@ public class ApplicationUtils {
     public static String getAppVersion() {
         return BuildConfig.VERSION_NAME;
     }
+
+    public static boolean isDebug() {
+        return BuildConfig.DEBUG;
+    }
 }

--- a/app/src/main/java/org/horaapps/leafpic/util/ArrayUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/ArrayUtils.java
@@ -1,0 +1,24 @@
+package org.horaapps.leafpic.util;
+
+import android.support.annotation.NonNull;
+
+/**
+ * All kinds of Array helpers belong here
+ */
+public final class ArrayUtils {
+
+    /**
+     * Find the index of an element in an array.
+     * Performs a linear search across the array.
+     *
+     * @param array   The array to search
+     * @param element The element to find
+     * @return The position of element in array, else -1 if not found.
+     */
+    public static <T> int getIndex(@NonNull T[] array, @NonNull T element) {
+        for (int pos = 0; pos < array.length; pos++) {
+            if (array[pos].equals(element)) return pos;
+        }
+        return -1;
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/DeviceUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/DeviceUtils.java
@@ -1,0 +1,25 @@
+package org.horaapps.leafpic.util;
+
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.support.annotation.NonNull;
+
+/**
+ * Utility class for accessing Android device-specific information
+ */
+public class DeviceUtils {
+
+    /**
+     * Returns the state of device being in Landscape orientation.
+     */
+    public static boolean isLandscape(@NonNull Resources resources) {
+        return resources.getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE;
+    }
+
+    /**
+     * Returns the state of device being in Portrait orientation.
+     */
+    public static boolean isPortrait(@NonNull Resources resources) {
+        return resources.getConfiguration().orientation == Configuration.ORIENTATION_PORTRAIT;
+    }
+}

--- a/app/src/main/java/org/horaapps/leafpic/util/StringUtils.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/StringUtils.java
@@ -2,12 +2,14 @@ package org.horaapps.leafpic.util;
 
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.text.Html;
 import android.text.Spanned;
 import android.widget.Toast;
 
 import org.horaapps.liz.ColorPalette;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -19,7 +21,7 @@ import java.util.regex.Pattern;
 public class StringUtils {
 
 
-    public static String[] asArray(String ... a) {
+    public static String[] asArray(String... a) {
         return a;
     }
 
@@ -59,7 +61,7 @@ public class StringUtils {
         String baseName = dot != -1 ? name.subSequence(0, dot).toString() : name;
         String nameWoSuffix = baseName;
         Matcher matcher = Pattern.compile("_\\d").matcher(baseName);
-        if(matcher.find()) {
+        if (matcher.find()) {
             int i = baseName.lastIndexOf("_");
             if (i != -1) nameWoSuffix = baseName.subSequence(0, i).toString();
         }
@@ -71,7 +73,7 @@ public class StringUtils {
     public static String getPhotoPathRenamedAlbumChange(String olderPath, String albumNewName) {
         String c = "", b[] = olderPath.split("/");
         for (int x = 0; x < b.length - 2; x++) c += b[x] + "/";
-        c += albumNewName +"/"+b[b.length - 1];
+        c += albumNewName + "/" + b[b.length - 1];
         return c;
     }
 
@@ -134,6 +136,18 @@ public class StringUtils {
         return String.format(Locale.ENGLISH,
                 "<font color='%s'>%s</font>",
                 color, content);
+    }
+
+    /**
+     * Returns a user-readable date formatted.
+     * eg: Sunday, 31 December 2017
+     *
+     * @param date The date object
+     * @return A user-readable date string.
+     */
+    public static String getUserReadableDate(@NonNull Date date) {
+        SimpleDateFormat dateFormatter = new SimpleDateFormat("E, d MMM yyyy", Locale.getDefault());
+        return dateFormatter.format(date);
     }
 
 }

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/Defaults.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/Defaults.java
@@ -18,6 +18,9 @@ public final class Defaults {
     public static final int MEDIA_COLUMNS_PORTRAIT = 3;
     public static final int MEDIA_COLUMNS_LANDSCAPE = 4;
 
+    public static final int TIMELINE_ITEMS_PORTRAIT = 4;
+    public static final int TIMELINE_ITEMS_LANDSCAPE = 5;
+
     public static final int ALBUM_SORTING_MODE = SortingMode.DATE.getValue();
     public static final int ALBUM_SORTING_ORDER = SortingOrder.DESCENDING.getValue();
     public static final int CARD_STYLE = CardViewStyle.MATERIAL.getValue();
@@ -31,5 +34,5 @@ public final class Defaults {
 
     public static final boolean ANIMATIONS_DISABLED = false;
 
-
+    public static final boolean TIMELINE_ENABLED = false;
 }

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/Keys.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/Keys.java
@@ -28,4 +28,6 @@ public final class Keys {
 
     public static final String ANIMATIONS_DISABLED = "disable_animations";
 
+    // Feature flags
+    public static final String TIMELINE_ENABLED = "enable_timeline";
 }

--- a/app/src/main/java/org/horaapps/leafpic/util/preferences/Prefs.java
+++ b/app/src/main/java/org/horaapps/leafpic/util/preferences/Prefs.java
@@ -113,6 +113,13 @@ public class Prefs {
     }
 
     /**
+     * Whether the Timeline view is enabled.
+     */
+    public static boolean timelineEnabled() {
+        return getPrefs().get(Keys.TIMELINE_ENABLED, Defaults.TIMELINE_ENABLED);
+    }
+
+    /**
      * Get the Card Style (Material / Flat / Compact)
      */
     @NonNull

--- a/app/src/main/java/org/horaapps/leafpic/views/navigation_drawer/NavigationDrawer.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/navigation_drawer/NavigationDrawer.java
@@ -22,6 +22,8 @@ import org.horaapps.liz.Themed;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 
+import static org.horaapps.leafpic.util.ApplicationUtils.isDebug;
+
 /**
  * Custom view which handles the home's Navigation Drawer.
  */
@@ -47,7 +49,8 @@ public class NavigationDrawer extends ScrollView implements Themed {
     @IntDef({NAVIGATION_ITEM_ALL_ALBUMS, NAVIGATION_ITEM_ALL_MEDIA, NAVIGATION_ITEM_HIDDEN_FOLDERS,
             NAVIGATION_ITEM_WALLPAPERS, NAVIGATION_ITEM_DONATE, NAVIGATION_ITEM_SETTINGS, NAVIGATION_ITEM_AFFIX,
             NAVIGATION_ITEM_EFFECTS, NAVIGATION_ITEM_ABOUT, NAVIGATION_ITEM_TIMELINE})
-    public @interface NavigationItem {}
+    public @interface NavigationItem {
+    }
 
     @BindView(R.id.navigation_drawer_header) ViewGroup drawerHeader;
 
@@ -134,7 +137,7 @@ public class NavigationDrawer extends ScrollView implements Themed {
      * Called on parent onStart. Use for any kind of refresh activities.
      */
     public void refresh() {
-        timelineEntry.setVisibility(Prefs.timelineEnabled() ? VISIBLE : GONE);
+        timelineEntry.setVisibility(isDebug() && Prefs.timelineEnabled() ? VISIBLE : GONE);
     }
 
     private void init(@NonNull Context context) {
@@ -176,16 +179,26 @@ public class NavigationDrawer extends ScrollView implements Themed {
     @NavigationItem
     private int getNavigationItemSelected(@IdRes int viewId) {
         switch (viewId) {
-            case R.id.navigation_item_albums: return NAVIGATION_ITEM_ALL_ALBUMS;
-            case R.id.navigation_item_all_media: return NAVIGATION_ITEM_ALL_MEDIA;
-            case R.id.navigation_item_timeline: return NAVIGATION_ITEM_TIMELINE;
-            case R.id.navigation_item_hidden_albums: return NAVIGATION_ITEM_HIDDEN_FOLDERS;
-            case R.id.navigation_item_wallpapers: return NAVIGATION_ITEM_WALLPAPERS;
-            case R.id.navigation_item_donate: return NAVIGATION_ITEM_DONATE;
-            case R.id.navigation_item_settings: return NAVIGATION_ITEM_SETTINGS;
-            case R.id.navigation_item_affix: return NAVIGATION_ITEM_AFFIX;
-            case R.id.navigation_item_effects: return NAVIGATION_ITEM_EFFECTS;
-            case R.id.navigation_item_about: return NAVIGATION_ITEM_ABOUT;
+            case R.id.navigation_item_albums:
+                return NAVIGATION_ITEM_ALL_ALBUMS;
+            case R.id.navigation_item_all_media:
+                return NAVIGATION_ITEM_ALL_MEDIA;
+            case R.id.navigation_item_timeline:
+                return NAVIGATION_ITEM_TIMELINE;
+            case R.id.navigation_item_hidden_albums:
+                return NAVIGATION_ITEM_HIDDEN_FOLDERS;
+            case R.id.navigation_item_wallpapers:
+                return NAVIGATION_ITEM_WALLPAPERS;
+            case R.id.navigation_item_donate:
+                return NAVIGATION_ITEM_DONATE;
+            case R.id.navigation_item_settings:
+                return NAVIGATION_ITEM_SETTINGS;
+            case R.id.navigation_item_affix:
+                return NAVIGATION_ITEM_AFFIX;
+            case R.id.navigation_item_effects:
+                return NAVIGATION_ITEM_EFFECTS;
+            case R.id.navigation_item_about:
+                return NAVIGATION_ITEM_ABOUT;
         }
         return NAVIGATION_ITEM_ABOUT;
     }
@@ -193,15 +206,24 @@ public class NavigationDrawer extends ScrollView implements Themed {
     @NonNull
     private NavigationEntry getViewForSelection(@NavigationItem int navItem) {
         switch (navItem) {
-            case NAVIGATION_ITEM_ABOUT: return aboutEntry;
-            case NAVIGATION_ITEM_ALL_ALBUMS: return albumsEntry;
-            case NAVIGATION_ITEM_ALL_MEDIA: return mediaEntry;
-            case NAVIGATION_ITEM_DONATE: return donateEntry;
-            case NAVIGATION_ITEM_HIDDEN_FOLDERS: return hiddenFoldersEntry;
-            case NAVIGATION_ITEM_SETTINGS: return settingsEntry;
-            case NAVIGATION_ITEM_WALLPAPERS: return wallpapersEntry;
-            case NAVIGATION_ITEM_TIMELINE: return timelineEntry;
-            default: return albumsEntry;
+            case NAVIGATION_ITEM_ABOUT:
+                return aboutEntry;
+            case NAVIGATION_ITEM_ALL_ALBUMS:
+                return albumsEntry;
+            case NAVIGATION_ITEM_ALL_MEDIA:
+                return mediaEntry;
+            case NAVIGATION_ITEM_DONATE:
+                return donateEntry;
+            case NAVIGATION_ITEM_HIDDEN_FOLDERS:
+                return hiddenFoldersEntry;
+            case NAVIGATION_ITEM_SETTINGS:
+                return settingsEntry;
+            case NAVIGATION_ITEM_WALLPAPERS:
+                return wallpapersEntry;
+            case NAVIGATION_ITEM_TIMELINE:
+                return timelineEntry;
+            default:
+                return albumsEntry;
         }
     }
 

--- a/app/src/main/java/org/horaapps/leafpic/views/navigation_drawer/NavigationDrawer.java
+++ b/app/src/main/java/org/horaapps/leafpic/views/navigation_drawer/NavigationDrawer.java
@@ -15,6 +15,7 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 
 import org.horaapps.leafpic.R;
+import org.horaapps.leafpic.util.preferences.Prefs;
 import org.horaapps.liz.ThemeHelper;
 import org.horaapps.liz.Themed;
 
@@ -35,6 +36,7 @@ public class NavigationDrawer extends ScrollView implements Themed {
     public static final int NAVIGATION_ITEM_AFFIX = 1007;
     public static final int NAVIGATION_ITEM_EFFECTS = 1008;
     public static final int NAVIGATION_ITEM_ABOUT = 1009;
+    public static final int NAVIGATION_ITEM_TIMELINE = 1010;
 
     @Override
     public void refreshTheme(ThemeHelper themeHelper) {
@@ -44,13 +46,14 @@ public class NavigationDrawer extends ScrollView implements Themed {
 
     @IntDef({NAVIGATION_ITEM_ALL_ALBUMS, NAVIGATION_ITEM_ALL_MEDIA, NAVIGATION_ITEM_HIDDEN_FOLDERS,
             NAVIGATION_ITEM_WALLPAPERS, NAVIGATION_ITEM_DONATE, NAVIGATION_ITEM_SETTINGS, NAVIGATION_ITEM_AFFIX,
-            NAVIGATION_ITEM_EFFECTS, NAVIGATION_ITEM_ABOUT})
+            NAVIGATION_ITEM_EFFECTS, NAVIGATION_ITEM_ABOUT, NAVIGATION_ITEM_TIMELINE})
     public @interface NavigationItem {}
 
     @BindView(R.id.navigation_drawer_header) ViewGroup drawerHeader;
 
     @BindView(R.id.navigation_item_albums) NavigationEntry albumsEntry;
     @BindView(R.id.navigation_item_all_media) NavigationEntry mediaEntry;
+    @BindView(R.id.navigation_item_timeline) NavigationEntry timelineEntry;
     @BindView(R.id.navigation_item_hidden_albums) NavigationEntry hiddenFoldersEntry;
     @BindView(R.id.navigation_item_wallpapers) NavigationEntry wallpapersEntry;
     @BindView(R.id.navigation_item_donate) NavigationEntry donateEntry;
@@ -127,6 +130,13 @@ public class NavigationDrawer extends ScrollView implements Themed {
         selectItem(getViewForSelection(navItem));
     }
 
+    /**
+     * Called on parent onStart. Use for any kind of refresh activities.
+     */
+    public void refresh() {
+        timelineEntry.setVisibility(Prefs.timelineEnabled() ? VISIBLE : GONE);
+    }
+
     private void init(@NonNull Context context) {
         setupView();
         LayoutInflater.from(context).inflate(R.layout.view_navigation_drawer, this, true);
@@ -134,7 +144,7 @@ public class NavigationDrawer extends ScrollView implements Themed {
 
         navigationEntries = new NavigationEntry[]
                 {albumsEntry, mediaEntry, hiddenFoldersEntry, wallpapersEntry, donateEntry,
-                        settingsEntry, affixEntry, effectsEntry ,aboutEntry};
+                        settingsEntry, affixEntry, effectsEntry, aboutEntry, timelineEntry};
         setupListeners();
 
         selectedEntry = albumsEntry;
@@ -168,6 +178,7 @@ public class NavigationDrawer extends ScrollView implements Themed {
         switch (viewId) {
             case R.id.navigation_item_albums: return NAVIGATION_ITEM_ALL_ALBUMS;
             case R.id.navigation_item_all_media: return NAVIGATION_ITEM_ALL_MEDIA;
+            case R.id.navigation_item_timeline: return NAVIGATION_ITEM_TIMELINE;
             case R.id.navigation_item_hidden_albums: return NAVIGATION_ITEM_HIDDEN_FOLDERS;
             case R.id.navigation_item_wallpapers: return NAVIGATION_ITEM_WALLPAPERS;
             case R.id.navigation_item_donate: return NAVIGATION_ITEM_DONATE;
@@ -189,6 +200,7 @@ public class NavigationDrawer extends ScrollView implements Themed {
             case NAVIGATION_ITEM_HIDDEN_FOLDERS: return hiddenFoldersEntry;
             case NAVIGATION_ITEM_SETTINGS: return settingsEntry;
             case NAVIGATION_ITEM_WALLPAPERS: return wallpapersEntry;
+            case NAVIGATION_ITEM_TIMELINE: return timelineEntry;
             default: return albumsEntry;
         }
     }

--- a/app/src/main/res/drawable/ic_group.xml
+++ b/app/src/main/res/drawable/ic_group.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -390,6 +390,17 @@
                         app:settingIcon="gmd-do-not-disturb"
                         app:settingPreferenceKey="@string/preference_disable_animations"
                         app:settingTitle="@string/disable_animations"/>
+
+                    <!-- Enable Timeline -->
+                    <org.horaapps.leafpic.views.SettingWithSwitchView
+                        android:id="@+id/option_enable_timeline"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:settingCaption="@string/enable_timeline_desc"
+                        app:settingIcon="@string/icon_timeline"
+                        app:settingPreferenceKey="@string/preference_enable_timeline"
+                        app:settingTitle="@string/enable_timeline_title"/>
+
                 </LinearLayout>
             </org.horaapps.leafpic.views.themeable.ThemedCardView>
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_timeline.xml
+++ b/app/src/main/res/layout/fragment_timeline.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/timeline_swipe_refresh_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/timeline_items"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="@dimen/timeline_decorator_spacing"
+        android:paddingLeft="@dimen/timeline_decorator_spacing"
+        android:paddingRight="@dimen/timeline_decorator_spacing"
+        android:paddingTop="@dimen/timeline_decorator_spacing"
+        android:scrollbarThumbVertical="@drawable/ic_scrollbar"
+        android:scrollbars="vertical" />
+
+</android.support.v4.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/view_navigation_drawer.xml
+++ b/app/src/main/res/layout/view_navigation_drawer.xml
@@ -66,6 +66,13 @@
                 app:itemText="@string/all_media" />
 
             <org.horaapps.leafpic.views.navigation_drawer.NavigationEntry
+                android:id="@+id/navigation_item_timeline"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:itemIcon="@string/icon_timeline"
+                app:itemText="@string/timeline" />
+
+            <org.horaapps.leafpic.views.navigation_drawer.NavigationEntry
                 android:id="@+id/navigation_item_hidden_albums"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/view_timeline_header.xml
+++ b/app/src/main/res/layout/view_timeline_header.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/timeline_container_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/timeline_header_text_padding"
+    android:textColor="@android:color/white"
+    android:textSize="@dimen/text_size_medium"
+    android:textStyle="bold"
+    tools:text="Wed, 14 May 2009" />

--- a/app/src/main/res/menu/menu_timeline.xml
+++ b/app/src/main/res/menu/menu_timeline.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="org.horaapps.leafpic.activities.MainActivity">
+
+    <item
+        android:id="@+id/filter_menu"
+        android:icon="@drawable/ic_group"
+        android:title="@string/timeline_grouping_menu_label"
+        app:showAsAction="ifRoom">
+
+        <menu xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            tools:context="org.horaapps.leafpic.activities.MainActivity">
+
+            <group android:checkableBehavior="single">
+
+                <item
+                    android:id="@+id/timeline_grouping_day"
+                    android:checked="true"
+                    android:title="@string/timeline_grouping_menu_day"
+                    app:showAsAction="never" />
+
+                <item
+                    android:id="@+id/timeline_grouping_week"
+                    android:title="@string/timeline_grouping_menu_week"
+                    app:showAsAction="never" />
+
+                <item
+                    android:id="@+id/timeline_grouping_month"
+                    android:title="@string/timeline_grouping_menu_month"
+                    app:showAsAction="never" />
+
+                <item
+                    android:id="@+id/timeline_grouping_year"
+                    android:title="@string/timeline_grouping_menu_year"
+                    app:showAsAction="never" />
+
+            </group>
+
+        </menu>
+
+    </item>
+
+</menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -48,4 +48,8 @@
     <dimen name="delete_bottom_sheet_progress_margin">16dp</dimen>
     <dimen name="delete_bottom_sheet_small_spacing">8dp</dimen>
 
+    <!-- Timeline Header -->
+    <dimen name="timeline_header_text_padding">10dp</dimen>
+    <dimen name="timeline_decorator_spacing">1dp</dimen>
+
 </resources>

--- a/app/src/main/res/values/icons.xml
+++ b/app/src/main/res/values/icons.xml
@@ -4,6 +4,7 @@
     <!-- Navigation Drawer -->
     <string name="icon_albums">gmd-folder</string>
     <string name="icon_all_media">gmd_photo_library</string>
+    <string name="icon_timeline">gmd-timeline</string>
     <string name="icon_hidden_folders">faw-low-vision</string>
     <string name="icon_tags">faw-tag</string>
     <string name="icon_wallpapers">gmd-wallpaper</string>

--- a/app/src/main/res/values/preferences-key.xml
+++ b/app/src/main/res/values/preferences-key.xml
@@ -9,6 +9,7 @@
     <string name="preference_auto_rotate">set_picture_orientation</string>
     <string name="preference_max_brightness">set_max_luminosity</string>
     <string name="preference_disable_animations">disable_animations</string>
+    <string name="preference_enable_timeline">enable_timeline</string>
 
 
     <string name="preference_apply_theme_pager">apply_theme_img_act</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -192,6 +192,8 @@ and this could make the media inaccessible from other apps. Use the exclude opti
     <string name="option_show_tips_sub">Helps you to understand the use of some features.</string>
     <string name="disable_animations">Disable Animations</string>
     <string name="disable_animations_sub">Disable animations if there are performance issues.</string>
+    <string name="enable_timeline_title">Enable Timeline</string>
+    <string name="enable_timeline_desc">Enable the Timeline view for media. Experimental.</string>
 
     <string name="media_viewer">Media Viewer</string>
     <string name="media_viewer_theme">Media Viewer Theme</string>
@@ -419,4 +421,12 @@ and this could make the media inaccessible from other apps. Use the exclude opti
     <string name="major_contributors">Major contributors</string>
     <string name="toolbar_selection_count" translatable="false">%1$d of %2$d</string>
     <string name="delete_bottom_sheet_title">Cleaning up memories…</string>
+
+    <!-- Timeline -->
+    <string name="timeline_grouping_menu_label">Grouping</string>
+    <string name="timeline_grouping_menu_day">Day</string>
+    <string name="timeline_grouping_menu_week">Week</string>
+    <string name="timeline_grouping_menu_month">Month</string>
+    <string name="timeline_grouping_menu_year">Year</string>
+
 </resources>


### PR DESCRIPTION
- Moved MediaListener to a separate interface.
- Added Timeline default grid sizes: Portrait - 4, Landscape - 5
- Added DeviceUtils utility class for getting Android device data.
- Added menu_timeline.xml to inflate the ActionBar menu.
- Added support to refresh items when Grouping Mode is changed.
- Added support to store the header text in TimelineHeaderModel.
- Added GroupingMode enum to sort the Timeline items.
- Added TimelineItem interface to specify that a given header / media
  is capable of being a Timeline item.
- Added Timeline ViewHolder class to store the TimelineHeaderViewHolder
  and TimelineMediaViewHolder classes and binding logic.
- Updated TimelineAdapter to use List of TimelineItems and
  recycle the types. Removed MediaAdapters.
- Updated TimelineHeaderModel to use Calendar instead of Date.
- Added TimelineItem, optimised RecyclerView implementations
- Added support to show Timeline in Navigation Drawer
- Added TimelineFragment to show the timeline.
- Added TimelineAdapter to show the Timeline contents.
- Minor refactoring at various places.

TODO
- Clean up implementation
- Add media selection
- Add support to sort - Ascending / Descending